### PR TITLE
Add Gyre Archives Flag

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -37,6 +37,7 @@ Extract the contents of the corresponding zip file to the same folder as Timespi
 * Achievements cannot be unlocked
 * SaveStatue inside right elevator room is disabled to prevent a softlock
 * SaveStatue down in the pit of the ancient pyramid is disabled to prevent a softlock
+* SaveStatues in front of Temportal Gyre bosses Ifrit and Ravenlord are disabled to prevent softlocks
 * Aelana and The Maw no longer require twins to be killed before their door unlocks
 
 # New keybinds
@@ -50,11 +51,11 @@ Extract the contents of the corresponding zip file to the same folder as Timespi
 * In Seed selection menu, Ctr+C can now be used to copy seed id to the clipboard
 
 # Routing changes
-* The drawbridge is now open by default, and doesn't require you to visit the twins demons
+* The drawbridge is now open by default, and doesn't require you to visit the demon twins
 * Amadeus Laboratory now requires keycard B to open
 * To prevent players from getting stuck in the past when items are still available in the present, the transition room next to the refugee camp can now be used to freely travel back and forth between past and present
 * When you obtain the pyramid keys, a random transition room is unlocked that could open new routing opportunities
-* The temporal gyre is closed, due to its high randomness inside an already randomized timezone, the timezone would be highly unstable
+* The Temporal Gyre's boss rooms are disconnected from its main loop, which instead exits to its entrance. When using the "Gyre Archives" flag, Ifrit can be reached by aquiring Kobo and proceeding to the room in the northwestern most room in the Library, while Ravenlord can be reached by aquiring Merchant Crow and proceeding to the room in Amadeus' Library containing the Historical Archives
 
 # Item Tracker
 The TsRandomizer.ItemTracker.exe can be used to automagicly track any progression item you obtain ingame. It can for example be used by streamers that want to display their current progression items to their viewers

--- a/TsRandomizer.ItemTracker/TrackerRenderer.cs
+++ b/TsRandomizer.ItemTracker/TrackerRenderer.cs
@@ -78,7 +78,8 @@ namespace TsRandomizerItemTracker
 				DrawItem(spriteBatch, state.CardE, new ItemIdentifier(EInventoryRelicType.ElevatorKeycard));
 				DrawItem(spriteBatch, state.WaterMask, new ItemIdentifier(EInventoryRelicType.WaterMask));
 				DrawItem(spriteBatch, state.GassMask, new ItemIdentifier(EInventoryRelicType.AirMask));
-
+				DrawItem(spriteBatch, state.Kobo, new ItemIdentifier(EInventoryFamiliarType.Kobo));
+				DrawItem(spriteBatch, state.MerchantCrow, new ItemIdentifier(EInventoryFamiliarType.MerchantCrow));
 				DrawFireSource(spriteBatch, state);
 				DrawPinkSource(spriteBatch, state);
 			}

--- a/TsRandomizer.ItemTracker/TrackerRenderer.cs
+++ b/TsRandomizer.ItemTracker/TrackerRenderer.cs
@@ -69,6 +69,7 @@ namespace TsRandomizerItemTracker
 				DrawItem(spriteBatch, state.CelestialSash, new ItemIdentifier(EInventoryRelicType.EssenceOfSpace));
 				DrawItem(spriteBatch, state.PyramidKeys, new ItemIdentifier(EInventoryRelicType.PyramidsKey));
 				DrawItem(spriteBatch, state.EyeRing, new ItemIdentifier(EInventoryOrbType.Eye, EOrbSlot.Passive));
+				DrawItem(spriteBatch, state.Kobo, new ItemIdentifier(EInventoryFamiliarType.Kobo));
 				DrawItem(spriteBatch, state.CardA, new ItemIdentifier(EInventoryRelicType.ScienceKeycardA));
 				DrawItem(spriteBatch, state.CardB, new ItemIdentifier(EInventoryRelicType.ScienceKeycardB));
 				DrawItem(spriteBatch, state.CardC, new ItemIdentifier(EInventoryRelicType.ScienceKeycardC));
@@ -78,10 +79,9 @@ namespace TsRandomizerItemTracker
 				DrawItem(spriteBatch, state.CardE, new ItemIdentifier(EInventoryRelicType.ElevatorKeycard));
 				DrawItem(spriteBatch, state.WaterMask, new ItemIdentifier(EInventoryRelicType.WaterMask));
 				DrawItem(spriteBatch, state.GassMask, new ItemIdentifier(EInventoryRelicType.AirMask));
-				DrawItem(spriteBatch, state.Kobo, new ItemIdentifier(EInventoryFamiliarType.Kobo));
-				DrawItem(spriteBatch, state.MerchantCrow, new ItemIdentifier(EInventoryFamiliarType.MerchantCrow));
 				DrawFireSource(spriteBatch, state);
 				DrawPinkSource(spriteBatch, state);
+				DrawItem(spriteBatch, state.MerchantCrow, new ItemIdentifier(EInventoryFamiliarType.MerchantCrow));
 			}
 		}
 

--- a/TsRandomizer/ItemTracker/ItemTrackerState.cs
+++ b/TsRandomizer/ItemTracker/ItemTrackerState.cs
@@ -12,7 +12,7 @@ namespace TsRandomizer.ItemTracker
 	[Serializable]
 	public class ItemTrackerState
 	{
-		public const int NumberOfItems = 27;
+		public const int NumberOfItems = 29;
 
 		public bool Timestop;
 		public bool TimeSpindle;
@@ -41,6 +41,8 @@ namespace TsRandomizer.ItemTracker
 		public bool PinkRing;
 		public bool Tablet;
 		public bool EyeRing;
+		public bool Kobo;
+		public bool MerchantCrow;
 
 		internal static ItemTrackerState FromItemLocationMap(IEnumerable<ItemLocation> itemLocations)
 		{
@@ -97,6 +99,8 @@ namespace TsRandomizer.ItemTracker
 			{new ItemIdentifier(EInventoryOrbType.Pink, EOrbSlot.Passive), s => s.PinkRing},
 			{new ItemIdentifier(EInventoryRelicType.Tablet), s => s.Tablet},
 			{new ItemIdentifier(EInventoryOrbType.Eye, EOrbSlot.Passive), s => s.EyeRing},
+			{new ItemIdentifier(EInventoryFamiliarType.Kobo), s => s.Kobo},
+			{new ItemIdentifier(EInventoryFamiliarType.MerchantCrow), s => s.MerchantCrow},
 		};
 
 		static void SetMemberForItem(ItemTrackerState trackerState, ItemIdentifier itemInfo)

--- a/TsRandomizer/LevelObjects/Other/GyrePortalEvent.cs
+++ b/TsRandomizer/LevelObjects/Other/GyrePortalEvent.cs
@@ -9,7 +9,7 @@ namespace TsRandomizer.LevelObjects.Other
 	{
 		public GyrePortalEvent(Mobile typedObject) : base(typedObject)
 		{
-			Dynamic._isUsable = false;
+			Dynamic._isUsable = true;
 		}
-	}
+    }
 }

--- a/TsRandomizer/LevelObjects/Other/GyrePortalEvent.cs
+++ b/TsRandomizer/LevelObjects/Other/GyrePortalEvent.cs
@@ -10,6 +10,9 @@ namespace TsRandomizer.LevelObjects.Other
 		public GyrePortalEvent(Mobile typedObject) : base(typedObject)
 		{
 			Dynamic._isUsable = true;
+			// Closed loop (end of dungeon becomes post-boss warp type)
+			if (typedObject.Level.ID == 14 && typedObject.Level.RoomID == 23)
+				Dynamic._portalType = 3;
 		}
-    }
+	}
 }

--- a/TsRandomizer/LevelObjects/Other/HistoricalDocuments.cs
+++ b/TsRandomizer/LevelObjects/Other/HistoricalDocuments.cs
@@ -1,0 +1,25 @@
+﻿using Timespinner.GameObjects.BaseClasses;
+using TsRandomizer.IntermediateObjects;
+using TsRandomizer.Screens;
+
+namespace TsRandomizer.LevelObjects.Other
+{
+	[TimeSpinnerType("Timespinner.GameObjects.Events.EnvironmentPrefabs.L11_Lab.EnvPrefabLabHistoricalDocuments")]
+	// ReSharper disable once UnusedMember.Global
+	class HistoricalDocuments: LevelObject
+	{
+		public HistoricalDocuments(Mobile typedObject) : base(typedObject)
+		{
+			TimeSpinnerGame.Localizer.OverrideKey("q_ram_4_lun_29alt",
+				"It says, 'Redacted Temporal Research: Lord of Ravens'. Maybe I should ask the crow about this...");
+		}
+
+		protected override void Initialize(SeedOptions options)
+		{
+		}
+        protected override void OnUpdate(GameplayScreen gameplayScreen)
+        {
+            base.OnUpdate(gameplayScreen);
+        }
+    }
+}

--- a/TsRandomizer/LevelObjects/Other/HistoricalDocuments.cs
+++ b/TsRandomizer/LevelObjects/Other/HistoricalDocuments.cs
@@ -1,6 +1,5 @@
 ﻿using Timespinner.GameObjects.BaseClasses;
 using TsRandomizer.IntermediateObjects;
-using TsRandomizer.Screens;
 
 namespace TsRandomizer.LevelObjects.Other
 {
@@ -13,13 +12,5 @@ namespace TsRandomizer.LevelObjects.Other
 			TimeSpinnerGame.Localizer.OverrideKey("q_ram_4_lun_29alt",
 				"It says, 'Redacted Temporal Research: Lord of Ravens'. Maybe I should ask the crow about this...");
 		}
-
-		protected override void Initialize(SeedOptions options)
-		{
-		}
-        protected override void OnUpdate(GameplayScreen gameplayScreen)
-        {
-            base.OnUpdate(gameplayScreen);
-        }
     }
 }

--- a/TsRandomizer/LevelObjects/Other/SaveStatue.cs
+++ b/TsRandomizer/LevelObjects/Other/SaveStatue.cs
@@ -22,8 +22,10 @@ namespace TsRandomizer.LevelObjects.Other
 			if (Dynamic._isBroken) 
 				return;
 
-			if ((Level.ID != 2 || Level.RoomID != 20) //Right side libarary elevator room
-				&& (Level.ID != 16 || Level.RoomID != 21))  //Pyramid Pit
+			if ((Level.ID != 2 || Level.RoomID != 20) // Right side libarary elevator room
+				&& (Level.ID != 16 || Level.RoomID != 21) // Pyramid pit
+				&& (Level.ID != 14 || Level.RoomID != 8) // Ravenlord
+				&& (Level.ID != 14 || Level.RoomID != 6))  // Ifrit
 				return;
 
 			Dynamic._isBroken = true;

--- a/TsRandomizer/LevelObjects/Other/YorneNPC.cs
+++ b/TsRandomizer/LevelObjects/Other/YorneNPC.cs
@@ -1,0 +1,27 @@
+﻿using Timespinner.GameObjects.BaseClasses;
+using TsRandomizer.IntermediateObjects;
+
+namespace TsRandomizer.LevelObjects.ItemManipulators
+{
+	[TimeSpinnerType("Timespinner.GameObjects.NPCs.YorneNPC")]
+	// ReSharper disable once UnusedMember.Global
+	class YorneNpc : LevelObject
+	{
+		public YorneNpc(Mobile typedObject) : base(typedObject)
+		{
+			if (typedObject.Level.ID == 2) // Copy of Yorne beyond backer room
+            {
+				TimeSpinnerGame.Localizer.OverrideKey("cs_pro_lun_02",
+					"Yorne? Oh... not quite. Is this... his memory?");
+				TimeSpinnerGame.Localizer.OverrideKey("cs_pro_yor_03",
+					"I still can't believe they picked *her*, I deserved this.");
+				TimeSpinnerGame.Localizer.OverrideKey("cs_pro_lun_04",
+					"*sigh* Even as just a reflection... Yorne is still as Yorne as ever.");
+				TimeSpinnerGame.Localizer.OverrideKey("cs_pro_yor_05",
+					"I have to find where that Kobo has run off to.");
+				TimeSpinnerGame.Localizer.OverrideKey("cs_pro_lun_06",
+					"'Kobo'... There's no one in our village by that name... I don't think this 'memory' is real.");
+			}
+		}
+	}
+}

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -22,6 +22,7 @@ namespace TsRandomizer.LevelObjects
 		static readonly LookupDictionairy<RoomItemKey, RoomTrigger> RoomTriggers = new LookupDictionairy<RoomItemKey, RoomTrigger>(rt => rt.key);
 
 		static readonly Type TransitionWarpEventType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.Doors.TransitionWarpEvent");
+		static readonly Type GyreType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.Doors.GyrePortalEvent");
 		static readonly Type NelisteNpcType = TimeSpinnerType.Get("Timespinner.GameObjects.NPCs.AstrologerNPC");
 		static readonly Type PedistalType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.Treasure.OrbPedestalEvent");
 		static readonly Type LakeVacuumLevelEffectType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.LevelEffects.LakeVacuumLevelEffect");
@@ -141,6 +142,31 @@ namespace TsRandomizer.LevelObjects
 				    || ((Dictionary<int, NPCBase>)level.AsDynamic()._npcs).Values.Any(npc => npc.GetType() == NelisteNpcType)) return;
 
 				SpawnNeliste(level);
+			}));
+			// Placeholder Gyre hooks TODO make objects for these
+			RoomTriggers.Add(new RoomTrigger(11, 4, (level, itemLocation, seedOptions, screenManager) =>
+			{
+				if (!seedOptions.GyreArchives || !level.GameSave.HasFamiliar(EInventoryFamiliarType.MerchantCrow)) return;
+				SpawnGyreWarp(level, 14, 8); // lab to ravenlord
+			}));
+			RoomTriggers.Add(new RoomTrigger(14, 24, (level, itemLocation, seedOptions, screenManager) =>
+			{
+				if (!seedOptions.GyreArchives) return;
+				SpawnGyreWarp(level, 11, 6); // ravenlord to lab
+			}));
+			RoomTriggers.Add(new RoomTrigger(2, 51, (level, itemLocation, seedOptions, screenManager) =>
+			{
+				if (!seedOptions.GyreArchives || !level.GameSave.HasFamiliar(EInventoryFamiliarType.Kobo)) return;
+				SpawnGyreWarp(level, 14, 6); // backer room to Ifrit
+			}));
+			RoomTriggers.Add(new RoomTrigger(14, 25, (level, itemLocation, seedOptions, screenManager) =>
+			{
+				if (!seedOptions.GyreArchives) return;
+				SpawnGyreWarp(level, 2, 3); // Ifrit to shop
+			}));
+			RoomTriggers.Add(new RoomTrigger(14, 23, (level, itemLocation, seedOptions, screenManager) =>
+			{
+				SpawnGyreWarp(level, 14, 0); // gyre closed loop
 			}));
 			RoomTriggers.Add(new RoomTrigger(12, 11, (level, itemLocation, seedOptions, screenManager) => //Remove Daddy's pedistal if you havent killed him yet
 			{
@@ -313,6 +339,11 @@ namespace TsRandomizer.LevelObjects
 			var neliste = (NPCBase)NelisteNpcType.CreateInstance(false, level, position, -1, new ObjectTileSpecification());
 
 			level.AsDynamic().RequestAddObject(neliste);
+		}
+
+		static void SpawnGyreWarp(Level level, int LevelId, int RoomId)
+		{
+			level.RequestChangeLevel(new LevelChangeRequest { LevelID = LevelId, RoomID = RoomId });
 		}
 
 		static void FillRoomWithGass(Level level)

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -24,6 +24,7 @@ namespace TsRandomizer.LevelObjects
 		static readonly Type TransitionWarpEventType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.Doors.TransitionWarpEvent");
 		static readonly Type GyreType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.Doors.GyrePortalEvent");
 		static readonly Type NelisteNpcType = TimeSpinnerType.Get("Timespinner.GameObjects.NPCs.AstrologerNPC");
+		static readonly Type YorneNpcType = TimeSpinnerType.Get("Timespinner.GameObjects.NPCs.YorneNPC");
 		static readonly Type PedistalType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.Treasure.OrbPedestalEvent");
 		static readonly Type LakeVacuumLevelEffectType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.LevelEffects.LakeVacuumLevelEffect");
 
@@ -156,8 +157,15 @@ namespace TsRandomizer.LevelObjects
 			}));
 			RoomTriggers.Add(new RoomTrigger(2, 51, (level, itemLocation, seedOptions, screenManager) =>
 			{
-				if (!seedOptions.GyreArchives || !level.GameSave.HasFamiliar(EInventoryFamiliarType.Kobo)) return;
-				SpawnGyreWarp(level, 14, 6); // backer room to Ifrit
+				if (!seedOptions.GyreArchives) return;
+
+				if (level.GameSave.HasFamiliar(EInventoryFamiliarType.Kobo)) {
+					SpawnGyreWarp(level, 14, 6); // backer room to Ifrit
+					return;
+				};
+
+				if (((Dictionary<int, NPCBase>)level.AsDynamic()._npcs).Values.Any(npc => npc.GetType() == YorneNpcType)) return;
+				SpawnYorne(level); // Dialog for needing Kobo
 			}));
 			RoomTriggers.Add(new RoomTrigger(14, 25, (level, itemLocation, seedOptions, screenManager) =>
 			{
@@ -339,6 +347,14 @@ namespace TsRandomizer.LevelObjects
 			var neliste = (NPCBase)NelisteNpcType.CreateInstance(false, level, position, -1, new ObjectTileSpecification());
 
 			level.AsDynamic().RequestAddObject(neliste);
+		}
+
+		static void SpawnYorne(Level level)
+		{
+			var position = new Point(240, 150);
+			var yorne = (NPCBase)YorneNpcType.CreateInstance(false, level, position, -1, new ObjectTileSpecification());
+
+			level.AsDynamic().RequestAddObject(yorne);
 		}
 
 		static void SpawnGyreWarp(Level level, int LevelId, int RoomId)

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -172,10 +172,6 @@ namespace TsRandomizer.LevelObjects
 				if (!seedOptions.GyreArchives) return;
 				SpawnGyreWarp(level, 2, 3); // Ifrit to shop
 			}));
-			RoomTriggers.Add(new RoomTrigger(14, 23, (level, itemLocation, seedOptions, screenManager) =>
-			{
-				SpawnGyreWarp(level, 14, 0); // gyre closed loop
-			}));
 			RoomTriggers.Add(new RoomTrigger(12, 11, (level, itemLocation, seedOptions, screenManager) => //Remove Daddy's pedistal if you havent killed him yet
 			{
 				if (level.GameSave.DataKeyBools.ContainsKey("IsEndingABCleared")) return;

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -78,6 +78,9 @@ namespace TsRandomizer.Randomisation
 			AddPastItemLocations();
 			AddPyramidItemLocations();
 
+			if (options.GyreArchives)
+				AddGyreItemLocations();
+
 			if (options.DownloadableItems)
 				AddDownloadTerminals();
 
@@ -373,15 +376,21 @@ namespace TsRandomizer.Randomisation
 			Add(new ItemKey(16, 3, 88, 192), "Conviction guarded room", ItemProvider.Get(EItemType.MaxHP), LeftPyramid);
 			Add(new ItemKey(16, 22, 200, 192), "Pit secret room", ItemProvider.Get(EItemType.MaxAura), Nightmare & OculusRift); //only requires LeftPyramid to reach but Nightmate to escape
 			Add(new ItemKey(16, 16, 1512, 144), "Regret chest", ItemProvider.Get(EInventoryRelicType.EssenceOfSpace), Nightmare & OculusRift); //only requires LeftPyramid to reach but Nightmate to escape
+			areaName = "Temporal Gyre"; // Main path is in pyramid logic, boss rooms are behind GyreArchives flag
+			Add(new ItemKey(14, 14, 200, 832), "Gyre Chest 1", null, Nightmare);
+			Add(new ItemKey(14, 17, 200, 832), "Gyre Chest 2", null, Nightmare);
+			Add(new ItemKey(14, 20, 200, 832), "Gyre Chest 3", null, Nightmare);
+		}
+
+		void AddGyreItemLocations()
+		{
 			areaName = "Temporal Gyre";
-			/*var challengeDungion = Nightmare;
-			Add(new ItemKey(14, 14, 200, 832), ItemInfo.Dummy, challengeDungion); //transition chest 1
-			Add(new ItemKey(14, 17, 200, 832), ItemInfo.Dummy, challengeDungion); //transition chest 2
-			Add(new ItemKey(14, 20, 200, 832), ItemInfo.Dummy, challengeDungion); //transition chest 3
-			Add(new ItemKey(14, 8, 120, 176), ItemInfo.Dummy, challengeDungion); //Ravenlord pre fight
-			Add(new ItemKey(14, 9, 280, 176), ItemInfo.Dummy, challengeDungion); //Ravenlord post fight
-			Add(new ItemKey(14, 6, 40, 208), ItemInfo.Dummy, challengeDungion); //ifrid pre fight
-			Add(new ItemKey(14, 7, 280, 208), ItemInfo.Dummy, challengeDungion); //ifrid post fight*/
+			Add(new ItemKey(14, 8, 120, 176), "Ravenlord Entry", null, UpperLab & R.MerchantCrow);
+			Add(new ItemKey(14, 9, 200, 125), "Ravenlord Pedestal", null, UpperLab & R.MerchantCrow);
+			Add(new ItemKey(14, 9, 280, 176), "Ravenlord Exit", null, UpperLab & R.MerchantCrow);
+			Add(new ItemKey(14, 6, 40, 208), "Ifrit Entry", null, UpperLeftLibrary & R.Kobo);
+			Add(new ItemKey(14, 7, 200, 205), "Ifrit Pedestal", null, UpperLeftLibrary & R.Kobo);
+			Add(new ItemKey(14, 7, 280, 208), "Ifrit Exit", null, UpperLeftLibrary & R.Kobo);
 		}
 
 		void AddDownloadTerminals()

--- a/TsRandomizer/Randomisation/ItemPlacers/ArchipelagoItemLocationRandomizer.cs
+++ b/TsRandomizer/Randomisation/ItemPlacers/ArchipelagoItemLocationRandomizer.cs
@@ -31,8 +31,8 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 		{
 			this.saveGame = saveGame;
 
-			TimeSpinnerGame.Localizar.OverrideKey("inv_use_MagicMarbles", "Archipelago Item");
-			TimeSpinnerGame.Localizar.OverrideKey("inv_use_MagicMarbles_desc", "Item that belongs to a distant timeline somewhere in the Archipelago");
+			TimeSpinnerGame.Localizer.OverrideKey("inv_use_MagicMarbles", "Archipelago Item");
+			TimeSpinnerGame.Localizer.OverrideKey("inv_use_MagicMarbles_desc", "Item that belongs to a distant timeline somewhere in the Archipelago");
 		}
 
 		public override ItemLocationMap GenerateItemLocationMap(bool isProgressionOnly)

--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -73,6 +73,8 @@ namespace TsRandomizer.Randomisation
 				new UnlockingSpecification(new ItemIdentifier(EInventoryRelicType.AirMask), R.GassMask),
 				new UnlockingSpecification(new ItemIdentifier(EInventoryRelicType.Tablet), R.Tablet),
 				new UnlockingSpecification(new ItemIdentifier(EInventoryOrbType.Eye, EOrbSlot.Passive), R.OculusRift),
+				new UnlockingSpecification(new ItemIdentifier(EInventoryFamiliarType.Kobo), R.Kobo),
+				new UnlockingSpecification(new ItemIdentifier(EInventoryFamiliarType.MerchantCrow), R.MerchantCrow),
 			};
 
 			if (seed.Options.SpecificKeys)

--- a/TsRandomizer/Randomisation/Requirement.cs
+++ b/TsRandomizer/Randomisation/Requirement.cs
@@ -35,6 +35,8 @@ namespace TsRandomizer.Randomisation
 		public static readonly Requirement TimespinnerWheel = 1UL << 26;
 		public static readonly Requirement Tablet = 1UL << 27;
 		public static readonly Requirement OculusRift = 1UL << 28;
+		public static readonly Requirement Kobo = 1UL << 29;
+		public static readonly Requirement MerchantCrow = 1UL << 30;
 
 		public static readonly Requirement GateSealedCaves = 1UL << 43;
 		public static readonly Requirement GateMaw = 1UL << 44;

--- a/TsRandomizer/Screens/GameDifficultyMenuScreen.cs
+++ b/TsRandomizer/Screens/GameDifficultyMenuScreen.cs
@@ -59,9 +59,9 @@ namespace TsRandomizer.Screens
 				((object)Dynamic._hardMenuEntry).AsDynamic().BaseDrawColor = MenuEntry.UnSelectedColor;
 				Dynamic._isHardModeAvailable = true;
 
-				string title = TimeSpinnerGame.Localizar.Get("DifficultyMenuHardCap1");
+				string title = TimeSpinnerGame.Localizer.Get("DifficultyMenuHardCap1");
 				var menuEntry = MenuEntry.Create(title, p => Dynamic.OnHardCap1EntrySelected(null, null));
-				menuEntry.Description = TimeSpinnerGame.Localizar.Get("DifficultyMenuHardLevelCap1Description");
+				menuEntry.Description = TimeSpinnerGame.Localizer.Get("DifficultyMenuHardLevelCap1Description");
 
 				AddMenuEntry(menuEntry);
 			}

--- a/TsRandomizer/Screens/MinimapScreen.cs
+++ b/TsRandomizer/Screens/MinimapScreen.cs
@@ -28,6 +28,40 @@ namespace TsRandomizer.Screens
 			new Roomkey(9, 7)
 		};
 
+		static readonly Roomkey[] GyreRooms =
+		{
+			// Gyre Path
+			new Roomkey(14, 11),
+			new Roomkey(14, 12),
+			new Roomkey(14, 13),
+			new Roomkey(14, 14),
+			new Roomkey(14, 15),
+			new Roomkey(14, 16),
+			new Roomkey(14, 17),
+			new Roomkey(14, 18),
+			new Roomkey(14, 19),
+			new Roomkey(14, 20),
+			new Roomkey(14, 21),
+			new Roomkey(14, 22),
+			new Roomkey(14, 23),
+			// Ravenlord
+			new Roomkey(14, 8),
+			new Roomkey(14, 4),
+			new Roomkey(14, 9),
+			new Roomkey(14, 24),
+			// Ifrit
+			new Roomkey(14, 6),
+			new Roomkey(14, 5),
+			new Roomkey(14, 7),
+			new Roomkey(14, 25)
+		};
+
+		static readonly Roomkey[] FalseWarpRooms =
+		{
+			new Roomkey(11, 4), // Lab cabinet
+			new Roomkey(2, 51) // Backer memory room
+		};
+
 		ItemLocationMap itemLocations;
 		bool isShowingAviableLocations;
 
@@ -62,6 +96,7 @@ namespace TsRandomizer.Screens
 						Height = room.Height,
 						Position = room.Position
 					};
+
 
 					foreach (var kvp in room.Blocks)
 					{
@@ -137,6 +172,9 @@ namespace TsRandomizer.Screens
 		{
 			var hud = ((object) Dynamic._minimapHud).AsDynamic();
 
+			foreach (var roomkey in GyreRooms)
+				GetRoom(roomkey).IsDebug = false;
+
 			hud._minimap = DeepClone(Dynamic._minimap);
 
 			itemLocations = itemLocationMap;
@@ -150,6 +188,10 @@ namespace TsRandomizer.Screens
 			foreach (var roomkey in BossRooms)
 				foreach (var block in GetRoom(roomkey).Blocks.Values)
 					block.IsBoss = true;
+
+			foreach (var roomkey in FalseWarpRooms)
+				foreach (var block in GetRoom(roomkey).Blocks.Values)
+					block.IsTimespinner = true;
 		}
 
 		public override void Update(GameTime gameTime, InputState input)

--- a/TsRandomizer/Screens/SaveSelectScreen.cs
+++ b/TsRandomizer/Screens/SaveSelectScreen.cs
@@ -201,8 +201,8 @@ namespace TsRandomizer.Screens
 			if (x == null) return;
 
 			string desc = (x._isCleared)
-				? TimeSpinnerGame.Localizar.Get("SaveSelectContClearedDescription")
-				: TimeSpinnerGame.Localizar.Get("SaveSelectContinueDescription");
+				? TimeSpinnerGame.Localizer.Get("SaveSelectContClearedDescription")
+				: TimeSpinnerGame.Localizer.Get("SaveSelectContinueDescription");
 
 			if (displayDeleteAll)
 			{

--- a/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
+++ b/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
@@ -18,6 +18,7 @@ namespace TsRandomizer.Screens.SeedSelection
 			{ 1 << 7, new SeedOptionInfo { Name = "Specific Keycards", Description = "Keycards can only open corresponding doors" } },
 			{ 1 << 8, new SeedOptionInfo { Name = "Inverted", Description = "Start in the past" } },
 			{ 1 << 9, new SeedOptionInfo { Name = "Stinky Maw", Description = "Require gassmask for Maw" } },
+			{ 1 << 10, new SeedOptionInfo { Name = "Gyre Archives", Description = "Gyre locations are in logic. New warps are gated by Merchant Crow and Kobo." } },
 		};
 
 		public SeedOptionsCollection(SeedOptions seedOptions)

--- a/TsRandomizer/SeedOptions.cs
+++ b/TsRandomizer/SeedOptions.cs
@@ -22,6 +22,7 @@ namespace TsRandomizer
 		public bool SpecificKeys => (Flags & 1 << 7) > 0;
 		public bool Inverted => (Flags & 1 << 8) > 0;
 		public bool GassMaw => (Flags & 1 << 9) > 0;
+		public bool GyreArchives => (Flags & 1 << 10) > 0;
 
 		//Non visable flags
 		public bool Archipelago => (Flags & 1 << 16) > 0;
@@ -48,6 +49,7 @@ namespace TsRandomizer
 				{"SpecificKeycards", 1U << 7},
 				{"Inverted", 1U << 8},
 				{"StinkyMaw", 1U << 9},
+				{"GyreArchives", 1U << 10},
 				{"DeathLink", 1U << 17}
 			};
 

--- a/TsRandomizer/TimeSpinnerGame.cs
+++ b/TsRandomizer/TimeSpinnerGame.cs
@@ -9,7 +9,7 @@ namespace TsRandomizer
 		readonly PlatformHelper platformHelper;
 
 		public static dynamic Constants => new Constants();
-		public static dynamic Localizar => new Localizer();
+		public static dynamic Localizer => new Localizer();
 
 		public TimeSpinnerGame(PlatformHelper platformHelper) : base(platformHelper)
 		{


### PR DESCRIPTION
This adds the Gyre Archives flag, which when enabled:
- Merchant Crow and Kobo familiars are added to the tracker as gating items
- The lab historical documents room warps the player to the Ravenlord boss when MC has been acquired
- The memory room past the backer room warps the player to the Ifrit boss when Kobo has been acquired
- The two rooms with psuedo warps have dialog pointing to the required familiars if entered before the familiars have been attained
- The pseudo warp rooms are marked on the map with dots like the Timespinners

In addition, the Gyre path is unlocked whether or not the flag is on, as its accessibility being the same as Nightmare means that it's three item checks cannot contain any progression items in a static seed, making these previously unavailable chests no different than other Pyramid checks. The end of the path warps back to the entrance rather than a boss room, making a static path. 

Lastly, all Gyre rooms are now visible on the map.

A note that the forced-warp transitions are harsh and could benefit from a proper animation, but the flag is fully functional as-is.