### PR TITLE
Gyre Animation Cleanup + Warp Shards only sold w/ Pyramid Key

### DIFF
--- a/TsRandomizer/LevelObjects/Other/HistoricalDocuments.cs
+++ b/TsRandomizer/LevelObjects/Other/HistoricalDocuments.cs
@@ -7,17 +7,15 @@ namespace TsRandomizer.LevelObjects.Other
 	// ReSharper disable once UnusedMember.Global
 	class HistoricalDocuments: LevelObject
 	{
-		bool gyreArchivesEnabled = false;
 		public HistoricalDocuments(Mobile typedObject) : base(typedObject)
 		{
-			if (gyreArchivesEnabled)
-				TimeSpinnerGame.Localizer.OverrideKey("q_ram_4_lun_29alt",
-					"It says, 'Redacted Temporal Research: Lord of Ravens'. Maybe I should ask the crow about this...");
 		}
 
 		protected override void Initialize(SeedOptions options)
 		{
-			gyreArchivesEnabled = options.GyreArchives;
+			if (options.GyreArchives)
+				TimeSpinnerGame.Localizer.OverrideKey("q_ram_4_lun_29alt",
+					"It says, 'Redacted Temporal Research: Lord of Ravens'. Maybe I should ask the crow about this...");
 		}
 	}
 }

--- a/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
+++ b/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
@@ -33,7 +33,6 @@ namespace TsRandomizer.LevelObjects.Other
                 _merchandiseInventory.AddItem(EInventoryUseItemType.Ether);
             }
             _merchandiseInventory.AddItem(EInventoryUseItemType.Biscuit);
-            _merchandiseInventory.AddItem(EInventoryUseItemType.Ether);
             _merchandiseInventory.AddItem(EInventoryUseItemType.Antidote);
             _merchandiseInventory.AddItem(EInventoryUseItemType.SandBottle);
             _merchandiseInventory.AddItem(EInventoryUseItemType.ChaosHeal);

--- a/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
+++ b/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
@@ -17,7 +17,11 @@ namespace TsRandomizer.LevelObjects.Other
 
         protected override void Initialize(SeedOptions options)
         {
-            _merchandiseInventory.AddItem(EInventoryUseItemType.WarpCard);
+            PlayerInventory inventory = Dynamic._level.GameSave.Inventory;
+
+            // Only sell warp shards if Pyramid Key is aquired
+            if (inventory.RelicInventory.IsRelicActive(EInventoryRelicType.PyramidsKey))
+                _merchandiseInventory.AddItem(EInventoryUseItemType.WarpCard);
             if (Dynamic._isInPresent)
             {
                 _merchandiseInventory.AddItem(EInventoryUseItemType.FuturePotion);

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -370,7 +370,7 @@ namespace TsRandomizer.LevelObjects
 
 		static void SpawnYorne(Level level)
 		{
-			var position = new Point(240, 150);
+			var position = new Point(240, 215);
 			var yorne = (NPCBase)YorneNpcType.CreateInstance(false, level, position, -1, new ObjectTileSpecification());
 
 			level.AsDynamic().RequestAddObject(yorne);

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -153,7 +153,16 @@ namespace TsRandomizer.LevelObjects
 			RoomTriggers.Add(new RoomTrigger(14, 24, (level, itemLocation, seedOptions, screenManager) =>
 			{
 				if (!seedOptions.GyreArchives) return;
-				level.RequestChangeLevel(new LevelChangeRequest { LevelID = 11, RoomID = 4 }); // Ravenlord to Historical Documents room
+
+				level.JukeBox.StopSong();
+				level.RequestChangeLevel(new LevelChangeRequest { 
+					LevelID = 11,
+					RoomID = 4,
+					IsUsingWarp = true,
+					IsUsingWhiteFadeOut = true,
+					FadeInTime = 0.5f,
+					FadeOutTime = 0.25f
+				}); // Ravenlord to Historical Documents room
 			}));
 			RoomTriggers.Add(new RoomTrigger(2, 51, (level, itemLocation, seedOptions, screenManager) =>
 			{
@@ -170,7 +179,15 @@ namespace TsRandomizer.LevelObjects
 			RoomTriggers.Add(new RoomTrigger(14, 25, (level, itemLocation, seedOptions, screenManager) =>
 			{
 				if (!seedOptions.GyreArchives) return;
-				level.RequestChangeLevel(new LevelChangeRequest { LevelID = 2, RoomID = 51 }); // Ifrit to Portrait room
+				level.JukeBox.StopSong();
+				level.RequestChangeLevel(new LevelChangeRequest {
+					LevelID = 2,
+					RoomID = 51,
+					IsUsingWarp = true,
+					IsUsingWhiteFadeOut = true,
+					FadeInTime = 0.5f,
+					FadeOutTime = 0.25f
+				}); // Ifrit to Portrait room
 			}));
 			RoomTriggers.Add(new RoomTrigger(12, 11, (level, itemLocation, seedOptions, screenManager) => //Remove Daddy's pedistal if you havent killed him yet
 			{

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -163,6 +163,7 @@ namespace TsRandomizer.LevelObjects
 					FadeInTime = 0.5f,
 					FadeOutTime = 0.25f
 				}); // Ravenlord to Historical Documents room
+				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Level11);
 			}));
 			RoomTriggers.Add(new RoomTrigger(2, 51, (level, itemLocation, seedOptions, screenManager) =>
 			{
@@ -188,6 +189,7 @@ namespace TsRandomizer.LevelObjects
 					FadeInTime = 0.5f,
 					FadeOutTime = 0.25f
 				}); // Ifrit to Portrait room
+				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Library);
 			}));
 			RoomTriggers.Add(new RoomTrigger(12, 11, (level, itemLocation, seedOptions, screenManager) => //Remove Daddy's pedistal if you havent killed him yet
 			{

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -175,12 +175,12 @@ namespace TsRandomizer.Randomisation
 
 		static int CalculateCapacity(SeedOptions options)
 		{
-			var capacity = 165;
+			var capacity = 168;
 
 			if (options.DownloadableItems)
 				capacity += 14;
 			if (options.GyreArchives)
-				capacity += 9;
+				capacity += 6;
 
 			return capacity;
 		}

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -104,8 +104,10 @@
     <Compile Include="Archipelago\DeathLinker.cs" />
     <Compile Include="Archipelago\SlotDataParser.cs" />
     <Compile Include="Extensions\DictionaryExtensions.cs" />
+    <Compile Include="LevelObjects\Other\HistoricalDocuments.cs" />
     <Compile Include="LevelObjects\Other\MerchantCrowNPC.cs" />
     <Compile Include="LevelObjects\Other\NightmareBoss.cs" />
+    <Compile Include="LevelObjects\Other\YorneNPC.cs" />
     <Compile Include="Randomisation\ExteralItemLocation.cs" />
     <Compile Include="Archipelago\Log.cs" />
     <Compile Include="Archipelago\Client.cs" />


### PR DESCRIPTION
# Gyre Fixes
- New classes added to solution
- Yorne does not fall through floor
- False return warps have proper animation
- Simplified dialog replace for file cabinet

# Shop fixes
- Warp shards are only sold if the Pyramid Keys are in possession (relic active but no one turns relics off)