### PR TITLE
Move Temporal Gyre to Lab Spider Hell (when Gyre Archives active)

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -57,7 +57,7 @@ Extract the contents of the corresponding zip file to the same folder as Timespi
 * Amadeus Laboratory now requires keycard B to open
 * To prevent players from getting stuck in the past when items are still available in the present, the transition room next to the refugee camp can now be used to freely travel back and forth between past and present
 * When you obtain the pyramid keys, a random transition room is unlocked that could open new routing opportunities
-* The Temporal Gyre's boss rooms are disconnected from its main loop, which instead exits to its entrance. When using the "Gyre Archives" flag, Ifrit can be reached by aquiring Kobo and proceeding to the portrait room in the Library, while Ravenlord can be reached by aquiring Merchant Crow and proceeding to the room in Amadeus' Laboratory containing the Historical Archives
+* When using the "Gyre Archives" flag, locations from the Temporal Gyre are accessible from the present. The main loop can be reached in the lab basement, Ifrit can be reached by aquiring Kobo and proceeding to the portrait room in the Library, while Ravenlord can be reached by aquiring Merchant Crow and proceeding to the room in Amadeus' Laboratory containing the Historical Archives
 
 # Item Tracker
 The TsRandomizer.ItemTracker.exe can be used to automagicly track any progression item you obtain ingame. It can for example be used by streamers that want to display their current progression items to their viewers

--- a/TsRandomizer/LevelObjects/Other/GyrePortalEvent.cs
+++ b/TsRandomizer/LevelObjects/Other/GyrePortalEvent.cs
@@ -10,21 +10,26 @@ namespace TsRandomizer.LevelObjects.Other
 		public GyrePortalEvent(Mobile typedObject) : base(typedObject)
 		{
 			Dynamic._isUsable = true;
+			// Lab spider hell
+			if (typedObject.Level.ID == 11 && typedObject.Level.RoomID == 26)
+				Dynamic._portalType = 0; // start
 			// Closed loop
-			if (typedObject.Level.ID == 14 && typedObject.Level.RoomID == 23)
+			else if (typedObject.Level.ID == 14 && typedObject.Level.RoomID == 23)
 				Dynamic._portalType = 3; // post-boss
 			// Lab file cabinet room
 			else if (typedObject.Level.ID == 11 && typedObject.Level.RoomID == 4)
-            {
+			{
 				Dynamic._portalType = 2; // post-dungeon
 				LevelReflected.SetLevelSaveInt("GyreDungeonSeed", 0); // Warp to Ravenlord
 			}
 			// Backer room
 			else if (typedObject.Level.ID == 2 && typedObject.Level.RoomID == 51)
-            {
+			{
 				Dynamic._portalType = 2; // post-dungeon
 				LevelReflected.SetLevelSaveInt("GyreDungeonSeed", 1); // Warp to Ifrit
 			}
+			else
+				Dynamic._isUsable = false;
 		}
 	}
 }

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -115,6 +115,9 @@ namespace TsRandomizer.LevelObjects
 			}));
 			RoomTriggers.Add(new RoomTrigger(11, 26, (level, itemLocation, seedOptions, screenManager) =>
 			{
+				if (seedOptions.GyreArchives)
+					SpawnGyreWarp(level, 200, 200); // Lab spider hell to main gyre path
+
 				if (itemLocation.IsPickedUp
 				    || !level.GameSave.HasRelic(EInventoryRelicType.TimespinnerGear1)) return;
 
@@ -169,7 +172,7 @@ namespace TsRandomizer.LevelObjects
 				if (!seedOptions.GyreArchives || !level.GameSave.HasFamiliar(EInventoryFamiliarType.MerchantCrow)) 
 					return;
 
-				SpawnGyreWarp(level); // Historical Documents room to Ravenlord
+				SpawnGyreWarp(level, 200, 200); // Historical Documents room to Ravenlord
 			}));
 			RoomTriggers.Add(new RoomTrigger(14, 24, (level, itemLocation, seedOptions, screenManager) =>
 			{
@@ -193,7 +196,7 @@ namespace TsRandomizer.LevelObjects
 			{
 				if (!seedOptions.GyreArchives) return;
 				if (level.GameSave.HasFamiliar(EInventoryFamiliarType.Kobo)) {
-					SpawnGyreWarp(level); // Portrait room to Ifrit
+					SpawnGyreWarp(level, 200, 200); // Portrait room to Ifrit
 					return;
 				};
 
@@ -213,6 +216,24 @@ namespace TsRandomizer.LevelObjects
 					FadeOutTime = 0.25f
 				}); // Ifrit to Portrait room
 				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Library);
+			}));
+			RoomTriggers.Add(new RoomTrigger(14, 11, (level, itemLocation, seedOptions, screenManager) => {
+				// Play Gyre music in gyre
+				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Level14);
+				level.AsDynamic().SetLevelSaveInt("GyreDungeonSeed", seedOptions.Flags.GetHashCode()); // Warp to Ravenlord
+			}));
+			RoomTriggers.Add(new RoomTrigger(14, 23, (level, itemLocation, seedOptions, screenManager) => {
+				level.JukeBox.StopSong();
+				level.RequestChangeLevel(new LevelChangeRequest
+				{
+					LevelID = 11,
+					RoomID = 26,
+					IsUsingWarp = true,
+					IsUsingWhiteFadeOut = true,
+					FadeInTime = 0.5f,
+					FadeOutTime = 0.25f
+				}); // Gyre back to spider-hell
+				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Level11);
 			}));
 			RoomTriggers.Add(new RoomTrigger(12, 11, (level, itemLocation, seedOptions, screenManager) => //Remove Daddy's pedistal if you havent killed him yet
 			{
@@ -401,9 +422,9 @@ namespace TsRandomizer.LevelObjects
 			level.AsDynamic().RequestAddObject(yorne);
 		}
 
-		static void SpawnGyreWarp(Level level)
+		static void SpawnGyreWarp(Level level, int x, int y)
 		{
-			var position = new Point(200, 200);
+			var position = new Point(x, y);
 			var gyrePortal = GyreType.CreateInstance(false, level, position, -1, new ObjectTileSpecification());
 
 			level.AsDynamic().RequestAddObject(gyrePortal);

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -181,12 +181,12 @@ namespace TsRandomizer.Randomisation
 
 		static int CalculateCapacity(SeedOptions options)
 		{
-			var capacity = 168;
+			var capacity = 165;
 
 			if (options.DownloadableItems)
 				capacity += 14;
 			if (options.GyreArchives)
-				capacity += 6;
+				capacity += 9;
 			if (options.Cantoran)
 				capacity++;
 			if (options.LoreChecks)
@@ -398,16 +398,16 @@ namespace TsRandomizer.Randomisation
 			Add(new ItemKey(16, 14, 312, 192), "Why not it's right there", ItemProvider.Get(EItemType.MaxSand), LeftPyramid);
 			Add(new ItemKey(16, 3, 88, 192), "Conviction guarded room", ItemProvider.Get(EItemType.MaxHP), LeftPyramid);
 			Add(new ItemKey(16, 22, 200, 192), "Pit secret room", ItemProvider.Get(EItemType.MaxAura), Nightmare & OculusRift); //only requires LeftPyramid to reach but Nightmate to escape
-			Add(new ItemKey(16, 16, 1512, 144), "Regret chest", ItemProvider.Get(EInventoryRelicType.EssenceOfSpace), Nightmare & OculusRift); //only requires LeftPyramid to reach but Nightmate to escape
-			areaName = "Temporal Gyre"; // Main path is in pyramid logic, boss rooms are behind GyreArchives flag
-			Add(new ItemKey(14, 14, 200, 832), "Gyre Chest 1", null, Nightmare);
-			Add(new ItemKey(14, 17, 200, 832), "Gyre Chest 2", null, Nightmare);
-			Add(new ItemKey(14, 20, 200, 832), "Gyre Chest 3", null, Nightmare);
+			Add(new ItemKey(16, 16, 1512, 144), "Regret chest", ItemProvider.Get(EInventoryRelicType.EssenceOfSpace), Nightmare & OculusRift); //only requires LeftPyramid to reach but Nightmate to escape	
 		}
 
 		void AddGyreItemLocations()
 		{
 			areaName = "Temporal Gyre";
+			// Wheel is not strictly required, but is in logic for anti-frustration against Nethershades
+			Add(new ItemKey(14, 14, 200, 832), "Gyre Chest 1", null, TheLabPoweredOff & R.CardA & R.TimespinnerWheel);
+			Add(new ItemKey(14, 17, 200, 832), "Gyre Chest 2", null, TheLabPoweredOff & R.CardA & R.TimespinnerWheel);
+			Add(new ItemKey(14, 20, 200, 832), "Gyre Chest 3", null, TheLabPoweredOff & R.CardA & R.TimespinnerWheel);
 			Add(new ItemKey(14, 8, 120, 176), "Ravenlord Entry", null, UpperLab & R.MerchantCrow);
 			Add(new ItemKey(14, 9, 200, 125), "Ravenlord Pedestal", null, UpperLab & R.MerchantCrow);
 			Add(new ItemKey(14, 9, 280, 176), "Ravenlord Exit", null, UpperLab & R.MerchantCrow);


### PR DESCRIPTION
This moves the entrance of the Gyre from ??? to spider hell in the lab basement. (the closed loop returns you to the basement, the portal in ??? is once again disabled)

As these three checks are now in pre-go mode logic, they have been moved behind the flag as the Gyre is a post game area (hence its placement in the lab, guarded by equally strong hell gazers)

Wheel is added as a soft requirement (the game expects you to have it so you don't have to wait for nethershades), but you can freely progress without it by timing out the nethershades.

Additionally, the gyre seed is now set to the randomizer seed, every time you enter it on a given seed, it will have the same enemy placement.