### PR TITLE
Move Gyre to Military Hangar

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -57,7 +57,7 @@ Extract the contents of the corresponding zip file to the same folder as Timespi
 * Amadeus Laboratory now requires keycard B to open
 * To prevent players from getting stuck in the past when items are still available in the present, the transition room next to the refugee camp can now be used to freely travel back and forth between past and present
 * When you obtain the pyramid keys, a random transition room is unlocked that could open new routing opportunities
-* The Temporal Gyre's boss rooms are disconnected from its main loop, which instead exits to its entrance. When using the "Gyre Archives" flag, Ifrit can be reached by aquiring Kobo and proceeding to the portrait room in the Library, while Ravenlord can be reached by aquiring Merchant Crow and proceeding to the room in Amadeus' Laboratory containing the Historical Archives
+* When using the "Gyre Archives" flag, locations from the Temporal Gyre are accessible from the present. The main loop can be reached in the lab basement, Ifrit can be reached by aquiring Kobo and proceeding to the portrait room in the Library, while Ravenlord can be reached by aquiring Merchant Crow and proceeding to the room in Amadeus' Laboratory containing the Historical Archives
 
 # Item Tracker
 The TsRandomizer.ItemTracker.exe can be used to automagicly track any progression item you obtain ingame. It can for example be used by streamers that want to display their current progression items to their viewers

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -57,7 +57,7 @@ Extract the contents of the corresponding zip file to the same folder as Timespi
 * Amadeus Laboratory now requires keycard B to open
 * To prevent players from getting stuck in the past when items are still available in the present, the transition room next to the refugee camp can now be used to freely travel back and forth between past and present
 * When you obtain the pyramid keys, a random transition room is unlocked that could open new routing opportunities
-* When using the "Gyre Archives" flag, locations from the Temporal Gyre are accessible from the present. The main loop can be reached in the lab basement, Ifrit can be reached by aquiring Kobo and proceeding to the portrait room in the Library, while Ravenlord can be reached by aquiring Merchant Crow and proceeding to the room in Amadeus' Laboratory containing the Historical Archives
+* When using the "Gyre Archives" flag, locations from the Temporal Gyre are accessible from the present. The main loop can be reached in the Military Hangar after clearing the past, Ifrit can be reached by aquiring Kobo and proceeding to the portrait room in the Library, while Ravenlord can be reached by aquiring Merchant Crow and proceeding to the room in Amadeus' Laboratory containing the Historical Archives
 
 # Item Tracker
 The TsRandomizer.ItemTracker.exe can be used to automagicly track any progression item you obtain ingame. It can for example be used by streamers that want to display their current progression items to their viewers

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -59,6 +59,20 @@ Extract the contents of the corresponding zip file to the same folder as Timespi
 * When you obtain the pyramid keys, a random transition room is unlocked that could open new routing opportunities
 * When using the "Gyre Archives" flag, locations from the Temporal Gyre are accessible from the present. The main loop can be reached in the Military Hangar after clearing the past, Ifrit can be reached by aquiring Kobo and proceeding to the portrait room in the Library, while Ravenlord can be reached by aquiring Merchant Crow and proceeding to the room in Amadeus' Laboratory containing the Historical Archives
 
+# Safety Checks
+Certain considerations were taken as anti-frustration changes in the seed routing. Sometimes this means certain items cannot appear in certain locations, other times it means while a difficult and/or tedious check may potentially be possible, the game will not consider it "in logic" until another requirement is reached.
+## General
+* Selen will not give you Plasma Orb as a starter melee orb, as it quickly drains a low-level Lunais' aura.
+* The warp rooms next to the bosses Azure Queen and Xarion are not in the selection pool for free warps from the Twin Pyramid Keys, as they could lead into immediate boss fights at the start of the seed.
+* The Military Hangar chest guarded by falling bombs requires the Timespinner Wheel, though can be reached without it by using the Celestial Sash.
+* The larger "Struggle Juggle" maneuver, which requires jumping off of and repositioning a frozen Royal Guard enemy multiple times is only in logic with double jumps available, even if technically possible with single jumps.
+* While Meyef is able to burn vines, they do not count as a fire source in logic. (Two vines can be burned in this fashion by aggroing enemies into the correct locations, while the third can be burned by a second player)
+* While possible to tank oxygen damage in poison areas (Lake Desolation post-Maw), doing so will not be considered in logic.
+* * Note that when the Stinky Maw flag is on, the plasma crystal is considered in logic with the Talaria attachment, as it is reachable without fully expending oxygen (i.e. before the damaging phase).
+## When using the Gyre Archives Flag
+* The Military Hangar portal will not be in logic until you possess the Timespinner Wheel. The items within can be obtained without it, but if you enter a room with a Nethershade you will have to wait for the room timer to expire, opening the doors.
+* Ifrit in the portrait room will not be required unless you have access to the past. This safeguard is to ensure that an early Ifrit fight does not block access to the past.
+
 # Item Tracker
 The TsRandomizer.ItemTracker.exe can be used to automagicly track any progression item you obtain ingame. It can for example be used by streamers that want to display their current progression items to their viewers
 The item tracker features a few options:

--- a/TsRandomizer/LevelObjects/Other/GyrePortalEvent.cs
+++ b/TsRandomizer/LevelObjects/Other/GyrePortalEvent.cs
@@ -10,8 +10,8 @@ namespace TsRandomizer.LevelObjects.Other
 		public GyrePortalEvent(Mobile typedObject) : base(typedObject)
 		{
 			Dynamic._isUsable = true;
-			// Lab spider hell
-			if (typedObject.Level.ID == 11 && typedObject.Level.RoomID == 26)
+			// Crash Site
+			if (typedObject.Level.ID == 10 && typedObject.Level.RoomID == 0)
 				Dynamic._portalType = 0; // start
 			// Closed loop
 			else if (typedObject.Level.ID == 14 && typedObject.Level.RoomID == 23)

--- a/TsRandomizer/LevelObjects/Other/GyrePortalEvent.cs
+++ b/TsRandomizer/LevelObjects/Other/GyrePortalEvent.cs
@@ -10,21 +10,26 @@ namespace TsRandomizer.LevelObjects.Other
 		public GyrePortalEvent(Mobile typedObject) : base(typedObject)
 		{
 			Dynamic._isUsable = true;
+			// Lab spider hell
+			if (typedObject.Level.ID == 11 && typedObject.Level.RoomID == 26)
+				Dynamic._portalType = 0; // start
 			// Closed loop
-			if (typedObject.Level.ID == 14 && typedObject.Level.RoomID == 23)
+			else if (typedObject.Level.ID == 14 && typedObject.Level.RoomID == 23)
 				Dynamic._portalType = 3; // post-boss
 			// Lab file cabinet room
 			else if (typedObject.Level.ID == 11 && typedObject.Level.RoomID == 4)
-            {
+			{
 				Dynamic._portalType = 2; // post-dungeon
 				LevelReflected.SetLevelSaveInt("GyreDungeonSeed", 0); // Warp to Ravenlord
 			}
 			// Backer room
 			else if (typedObject.Level.ID == 2 && typedObject.Level.RoomID == 51)
-            {
+			{
 				Dynamic._portalType = 2; // post-dungeon
 				LevelReflected.SetLevelSaveInt("GyreDungeonSeed", 1); // Warp to Ifrit
 			}
+			else
+				Dynamic._isUsable = false;
 		}
 	}
 }

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -115,9 +115,6 @@ namespace TsRandomizer.LevelObjects
 			}));
 			RoomTriggers.Add(new RoomTrigger(11, 26, (level, itemLocation, seedOptions, screenManager) =>
 			{
-				if (seedOptions.GyreArchives)
-					SpawnGyreWarp(level, 200, 200); // Lab spider hell to main gyre path
-
 				if (itemLocation.IsPickedUp
 				    || !level.GameSave.HasRelic(EInventoryRelicType.TimespinnerGear1)) return;
 
@@ -217,6 +214,12 @@ namespace TsRandomizer.LevelObjects
 				}); // Ifrit to Portrait room
 				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Library);
 			}));
+			RoomTriggers.Add(new RoomTrigger(10, 0, (level, itemLocation, seedOptions, screenManager) => {
+				// Spawn warp after ship crashes
+				if (!seedOptions.GyreArchives || !level.GameSave.GetSaveBool("IsPastCleared"))
+					return;
+				SpawnGyreWarp(level, 340, 180); // Military Hangar crash site to Gyre
+			}));
 			RoomTriggers.Add(new RoomTrigger(14, 11, (level, itemLocation, seedOptions, screenManager) => {
 				// Play Gyre music in gyre
 				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Level14);
@@ -226,16 +229,16 @@ namespace TsRandomizer.LevelObjects
 				level.JukeBox.StopSong();
 				level.RequestChangeLevel(new LevelChangeRequest
 				{
-					LevelID = 11,
-					RoomID = 26,
+					LevelID = 10,
+					RoomID = 0,
 					IsUsingWarp = true,
 					IsUsingWhiteFadeOut = true,
 					FadeInTime = 0.5f,
 					FadeOutTime = 0.25f
-				}); // Gyre back to spider-hell
-				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Level11);
+				}); // Military Hangar crash site
+				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Level10);
 			}));
-			RoomTriggers.Add(new RoomTrigger(12, 11, (level, itemLocation, seedOptions, screenManager) => //Remove Daddy's pedistal if you havent killed him yet
+			RoomTriggers.Add(new RoomTrigger(12, 11, (level, itemLocation, seedOptions, screenManager) => //Remove Daddy's pedestal if you havent killed him yet
 			{
 				if (level.GameSave.DataKeyBools.ContainsKey("IsEndingABCleared")) return;
 

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -115,6 +115,9 @@ namespace TsRandomizer.LevelObjects
 			}));
 			RoomTriggers.Add(new RoomTrigger(11, 26, (level, itemLocation, seedOptions, screenManager) =>
 			{
+				if (seedOptions.GyreArchives)
+					SpawnGyreWarp(level, 200, 200); // Lab spider hell to main gyre path
+
 				if (itemLocation.IsPickedUp
 				    || !level.GameSave.HasRelic(EInventoryRelicType.TimespinnerGear1)) return;
 
@@ -169,7 +172,7 @@ namespace TsRandomizer.LevelObjects
 				if (!seedOptions.GyreArchives || !level.GameSave.HasFamiliar(EInventoryFamiliarType.MerchantCrow)) 
 					return;
 
-				SpawnGyreWarp(level); // Historical Documents room to Ravenlord
+				SpawnGyreWarp(level, 200, 200); // Historical Documents room to Ravenlord
 			}));
 			RoomTriggers.Add(new RoomTrigger(14, 24, (level, itemLocation, seedOptions, screenManager) =>
 			{
@@ -193,7 +196,7 @@ namespace TsRandomizer.LevelObjects
 			{
 				if (!seedOptions.GyreArchives) return;
 				if (level.GameSave.HasFamiliar(EInventoryFamiliarType.Kobo)) {
-					SpawnGyreWarp(level); // Portrait room to Ifrit
+					SpawnGyreWarp(level, 200, 200); // Portrait room to Ifrit
 					return;
 				};
 
@@ -213,6 +216,24 @@ namespace TsRandomizer.LevelObjects
 					FadeOutTime = 0.25f
 				}); // Ifrit to Portrait room
 				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Library);
+			}));
+			RoomTriggers.Add(new RoomTrigger(14, 11, (level, itemLocation, seedOptions, screenManager) => {
+				// Play Gyre music in gyre
+				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Level14);
+				level.AsDynamic().SetLevelSaveInt("GyreDungeonSeed", seedOptions.Flags.GetHashCode()); // Warp to Ravenlord
+			}));
+			RoomTriggers.Add(new RoomTrigger(14, 23, (level, itemLocation, seedOptions, screenManager) => {
+				level.JukeBox.StopSong();
+				level.RequestChangeLevel(new LevelChangeRequest
+				{
+					LevelID = 11,
+					RoomID = 26,
+					IsUsingWarp = true,
+					IsUsingWhiteFadeOut = true,
+					FadeInTime = 0.5f,
+					FadeOutTime = 0.25f
+				}); // Gyre back to spider-hell
+				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Level11);
 			}));
 			RoomTriggers.Add(new RoomTrigger(12, 11, (level, itemLocation, seedOptions, screenManager) => //Remove Daddy's pedistal if you havent killed him yet
 			{
@@ -401,9 +422,9 @@ namespace TsRandomizer.LevelObjects
 			level.AsDynamic().RequestAddObject(yorne);
 		}
 
-		static void SpawnGyreWarp(Level level)
+		static void SpawnGyreWarp(Level level, int x, int y)
 		{
-			var position = new Point(200, 200);
+			var position = new Point(x, y);
 			var gyrePortal = GyreType.CreateInstance(false, level, position, -1, new ObjectTileSpecification());
 
 			level.AsDynamic().RequestAddObject(gyrePortal);

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -405,15 +405,16 @@ namespace TsRandomizer.Randomisation
 		{
 			areaName = "Temporal Gyre";
 			// Wheel is not strictly required, but is in logic for anti-frustration against Nethershades
-			Add(new ItemKey(14, 14, 200, 832), "Gyre Chest 1", null, TheLabPoweredOff & R.CardA & R.TimespinnerWheel);
-			Add(new ItemKey(14, 17, 200, 832), "Gyre Chest 2", null, TheLabPoweredOff & R.CardA & R.TimespinnerWheel);
-			Add(new ItemKey(14, 20, 200, 832), "Gyre Chest 3", null, TheLabPoweredOff & R.CardA & R.TimespinnerWheel);
+			Add(new ItemKey(14, 14, 200, 832), "Gyre Chest 1", null, MilitaryFortress & R.TimespinnerWheel);
+			Add(new ItemKey(14, 17, 200, 832), "Gyre Chest 2", null, MilitaryFortress & R.TimespinnerWheel);
+			Add(new ItemKey(14, 20, 200, 832), "Gyre Chest 3", null, MilitaryFortress & R.TimespinnerWheel);
 			Add(new ItemKey(14, 8, 120, 176), "Ravenlord Entry", null, UpperLab & R.MerchantCrow);
 			Add(new ItemKey(14, 9, 200, 125), "Ravenlord Pedestal", null, UpperLab & R.MerchantCrow);
 			Add(new ItemKey(14, 9, 280, 176), "Ravenlord Exit", null, UpperLab & R.MerchantCrow);
-			Add(new ItemKey(14, 6, 40, 208), "Ifrit Entry", null, UpperLeftLibrary & R.Kobo);
-			Add(new ItemKey(14, 7, 200, 205), "Ifrit Pedestal", null, UpperLeftLibrary & R.Kobo);
-			Add(new ItemKey(14, 7, 280, 208), "Ifrit Exit", null, UpperLeftLibrary & R.Kobo);
+			// Ifrit is a strong early boss, access to the past is required as a safety check so that they do not block past access
+			Add(new ItemKey(14, 6, 40, 208), "Ifrit Entry", null, UpperLeftLibrary & R.Kobo & AccessToPast);
+			Add(new ItemKey(14, 7, 200, 205), "Ifrit Pedestal", null, UpperLeftLibrary & R.Kobo & AccessToPast);
+			Add(new ItemKey(14, 7, 280, 208), "Ifrit Exit", null, UpperLeftLibrary & R.Kobo & AccessToPast);
 		}
 
 		void AddDownloadTerminals()

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -181,12 +181,12 @@ namespace TsRandomizer.Randomisation
 
 		static int CalculateCapacity(SeedOptions options)
 		{
-			var capacity = 168;
+			var capacity = 165;
 
 			if (options.DownloadableItems)
 				capacity += 14;
 			if (options.GyreArchives)
-				capacity += 6;
+				capacity += 9;
 			if (options.Cantoran)
 				capacity++;
 			if (options.LoreChecks)
@@ -398,16 +398,16 @@ namespace TsRandomizer.Randomisation
 			Add(new ItemKey(16, 14, 312, 192), "Why not it's right there", ItemProvider.Get(EItemType.MaxSand), LeftPyramid);
 			Add(new ItemKey(16, 3, 88, 192), "Conviction guarded room", ItemProvider.Get(EItemType.MaxHP), LeftPyramid);
 			Add(new ItemKey(16, 22, 200, 192), "Pit secret room", ItemProvider.Get(EItemType.MaxAura), Nightmare & OculusRift); //only requires LeftPyramid to reach but Nightmate to escape
-			Add(new ItemKey(16, 16, 1512, 144), "Regret chest", ItemProvider.Get(EInventoryRelicType.EssenceOfSpace), Nightmare & OculusRift); //only requires LeftPyramid to reach but Nightmate to escape
-			areaName = "Temporal Gyre"; // Main path is in pyramid logic, boss rooms are behind GyreArchives flag
-			Add(new ItemKey(14, 14, 200, 832), "Gyre Chest 1", null, Nightmare);
-			Add(new ItemKey(14, 17, 200, 832), "Gyre Chest 2", null, Nightmare);
-			Add(new ItemKey(14, 20, 200, 832), "Gyre Chest 3", null, Nightmare);
+			Add(new ItemKey(16, 16, 1512, 144), "Regret chest", ItemProvider.Get(EInventoryRelicType.EssenceOfSpace), Nightmare & OculusRift); //only requires LeftPyramid to reach but Nightmate to escape	
 		}
 
 		void AddGyreItemLocations()
 		{
 			areaName = "Temporal Gyre";
+			// Wheel is not strictly required, but is in logic for anti-frustration against Nethershades
+			Add(new ItemKey(14, 14, 200, 832), "Gyre Chest 1", null, TheLabPoweredOff & R.CardA & R.TimespinnerWheel);
+			Add(new ItemKey(14, 17, 200, 832), "Gyre Chest 2", null, TheLabPoweredOff & R.CardA & R.TimespinnerWheel);
+			Add(new ItemKey(14, 20, 200, 832), "Gyre Chest 3", null, TheLabPoweredOff & R.CardA & R.TimespinnerWheel);
 			Add(new ItemKey(14, 8, 120, 176), "Ravenlord Entry", null, UpperLab & R.MerchantCrow);
 			Add(new ItemKey(14, 9, 200, 125), "Ravenlord Pedestal", null, UpperLab & R.MerchantCrow);
 			Add(new ItemKey(14, 9, 280, 176), "Ravenlord Exit", null, UpperLab & R.MerchantCrow);

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -33,7 +33,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\Timespinner\</OutputPath>
+    <OutputPath>..\..\TestVersions\DRMFreeVersion\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -101,12 +101,6 @@
     <Compile Include="Archipelago\ArchipelagoItemLocationMap.cs" />
     <Compile Include="Archipelago\ArchipelagoRemoteItem.cs" />
     <Compile Include="Archipelago\ConnectionFailedException.cs" />
-    <Compile Include="Commands\ConnectCommand.cs" />
-    <Compile Include="Commands\ConsoleCommand.cs" />
-    <Compile Include="Commands\TeleportCommand.cs" />
-    <Compile Include="LevelObjects\ItemManipulators\JournalMemoryEvent+JournalLetterEvent.cs" />
-    <Compile Include="Randomisation\HintGenerator.cs" />
-    <Compile Include="Screens\GameConsole.cs" />
     <Compile Include="Archipelago\DeathLinker.cs" />
     <Compile Include="Archipelago\SlotDataParser.cs" />
     <Compile Include="Extensions\DictionaryExtensions.cs" />
@@ -173,7 +167,6 @@
     <Compile Include="Randomisation\ItemPlacers\FullRandomItemLocationRandomizer.cs" />
     <Compile Include="Randomisation\ItemPlacers\ItemLocationRandomizer.cs" />
     <Compile Include="Randomisation\ItemUnlockingMap.cs" />
-    <Compile Include="Randomisation\OrbDamageManager.cs" />
     <Compile Include="Randomisation\RoomItemKey.cs" />
     <Compile Include="ReplacementObjects\TalariaAttachment.cs" />
     <Compile Include="ReplacementObjects\TimespinnerGearItem.cs" />
@@ -220,7 +213,7 @@
     <Compile Include="TimeSpinnerGame.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="LookupDictionary.cs" />
+    <Compile Include="LookupDictionairy.cs" />
     <Compile Include="ReplacementObjects\TimeSpinnerWheel.cs" />
     <Compile Include="Screens\Menu\MenuEntry.cs" />
     <Compile Include="Screens\Screen.cs" />
@@ -237,8 +230,6 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup>
-    <None Include=".editorconfig" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -101,6 +101,12 @@
     <Compile Include="Archipelago\ArchipelagoItemLocationMap.cs" />
     <Compile Include="Archipelago\ArchipelagoRemoteItem.cs" />
     <Compile Include="Archipelago\ConnectionFailedException.cs" />
+    <Compile Include="Commands\ConnectCommand.cs" />
+    <Compile Include="Commands\ConsoleCommand.cs" />
+    <Compile Include="Commands\TeleportCommand.cs" />
+    <Compile Include="LevelObjects\ItemManipulators\JournalMemoryEvent+JournalLetterEvent.cs" />
+    <Compile Include="Randomisation\HintGenerator.cs" />
+    <Compile Include="Screens\GameConsole.cs" />
     <Compile Include="Archipelago\DeathLinker.cs" />
     <Compile Include="Archipelago\SlotDataParser.cs" />
     <Compile Include="Extensions\DictionaryExtensions.cs" />
@@ -167,6 +173,7 @@
     <Compile Include="Randomisation\ItemPlacers\FullRandomItemLocationRandomizer.cs" />
     <Compile Include="Randomisation\ItemPlacers\ItemLocationRandomizer.cs" />
     <Compile Include="Randomisation\ItemUnlockingMap.cs" />
+    <Compile Include="Randomisation\OrbDamageManager.cs" />
     <Compile Include="Randomisation\RoomItemKey.cs" />
     <Compile Include="ReplacementObjects\TalariaAttachment.cs" />
     <Compile Include="ReplacementObjects\TimespinnerGearItem.cs" />
@@ -213,7 +220,7 @@
     <Compile Include="TimeSpinnerGame.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="LookupDictionairy.cs" />
+    <Compile Include="LookupDictionary.cs" />
     <Compile Include="ReplacementObjects\TimeSpinnerWheel.cs" />
     <Compile Include="Screens\Menu\MenuEntry.cs" />
     <Compile Include="Screens\Screen.cs" />
@@ -230,6 +237,8 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include=".editorconfig" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -33,7 +33,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\TestVersions\DRMFreeVersion\</OutputPath>
+    <OutputPath>..\..\Timespinner\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32756996/146096794-6ec62b39-8bc9-492f-97dc-c09cac2ae9d0.png)
Moves the Gyre main path into logic, in the crashed Military Hangar spaceship after clearing the past (an empty room that is always passed by on every seed and requires decent progression)

Gyre in ??? has been disabled again, leaving only the alternate portals open.

Safety checks (spots technically possible but lenient in logic):
- Ifrit requires AccessToPast so that they cannot block access to the past (potential to encounter them at level 2 with only dash and them having keycards, pyramid keys, etc. otherwise). they're cheeseable but they have 5000 HP so it's best to not force them without opening up a few more checks first
- Gyre requires Wheel so that you don't have to wait for Nethershade rooms to time out
- 