### PR TITLE
Change lore description text to specify 'letters'

### DIFF
--- a/TsRandomizer/Archipelago/LocationMap.cs
+++ b/TsRandomizer/Archipelago/LocationMap.cs
@@ -231,7 +231,7 @@ namespace TsRandomizer.Archipelago
 				{1337185, new ItemKey(11, 7, 248, 129)},
 				{1337186, new ItemKey(11, 7, 296, 129)},
 				{1337187, new ItemKey(12, 19, 56, 145)},
-				// Journals (Past)
+				// Letters (Past)
 				{1337188, new ItemKey(3, 12, 472, 161)},
 				{1337189, new ItemKey(3, 15, 328, 97)},
 				{1337190, new ItemKey(4, 18, 456, 497)},

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -466,23 +466,23 @@ namespace TsRandomizer.Randomisation
 			Add(new ItemKey(11, 7, 296, 129), "Memory - Genza's Secret Stash 2 (Twilight Dinner)", null, TheLab & OculusRift);
 			areaName = "Emperor's Tower";
 			Add(new ItemKey(12, 19, 56, 145), "Memory - Way Up There (Final Circle)", null, EmperorsTower & DoubleJumpOfNpc);
-			// Journals
+			// Letters
 			areaName = "Forest";
-			Add(new ItemKey(3, 12, 472, 161), "Journal - Forest Rats (Lachiem Expedition)", null, AccessToPast);
-			Add(new ItemKey(3, 15, 328, 97), "Journal - Forest Bat Jump Ledge (Peace Treaty)", null, AccessToPast & (DoubleJumpOfNpc | ForwardDashDoubleJump | (R.TimeStop & R.ForwardDash)));
+			Add(new ItemKey(3, 12, 472, 161), "Letter - Forest Rats (Lachiem Expedition)", null, AccessToPast);
+			Add(new ItemKey(3, 15, 328, 97), "Letter - Forest Bat Jump Ledge (Peace Treaty)", null, AccessToPast & (DoubleJumpOfNpc | ForwardDashDoubleJump | (R.TimeStop & R.ForwardDash)));
 			areaName = "Castle Ramparts";
-			Add(new ItemKey(4, 18, 456, 497), "Journal - Floating in Moat (Prime Edicts)", null, CastleRamparts);
-			Add(new ItemKey(4, 11, 360, 161), "Journal - Archer + Knight (Declaration of Independence)", null, CastleRamparts);
+			Add(new ItemKey(4, 18, 456, 497), "Letter - Floating in Moat (Prime Edicts)", null, CastleRamparts);
+			Add(new ItemKey(4, 11, 360, 161), "Letter - Archer + Knight (Declaration of Independence)", null, CastleRamparts);
 			areaName = "Castle Keep";
-			Add(new ItemKey(5, 41, 184, 177), "Journal - Under the Twins (Letter of Reference)", null, CastleKeep);
-			Add(new ItemKey(5, 44, 264, 161), "Journal - Castle Loop Giantess (Political Advice)", null, CastleKeep);
-			Add(new ItemKey(5, 14, 568, 177), "Journal - Aleana's Room (Diplomatic Missive)", null, CastleKeep & R.PinkOrb & R.DoubleJump);
+			Add(new ItemKey(5, 41, 184, 177), "Letter - Under the Twins (Letter of Reference)", null, CastleKeep);
+			Add(new ItemKey(5, 44, 264, 161), "Letter - Castle Loop Giantess (Political Advice)", null, CastleKeep);
+			Add(new ItemKey(5, 14, 568, 177), "Letter - Aleana's Room (Diplomatic Missive)", null, CastleKeep & R.PinkOrb & R.DoubleJump);
 			areaName = "Royal Towers";
-			Add(new ItemKey(6, 17, 344, 433), "Journal - Top Struggle Juggle Base (War of the Sisters)", null, UpperRoyalTower);
-			Add(new ItemKey(6, 14, 136, 177), "Journal - Aleana Boss (Stained Letter)", null, UpperRoyalTower);
-			Add(new ItemKey(6, 25, 152, 145), "Journal - Near Bottom Struggle Juggle (Mission Findings)", null, UpperRoyalTower & DoubleJumpOfNpc);
+			Add(new ItemKey(6, 17, 344, 433), "Letter - Top Struggle Juggle Base (War of the Sisters)", null, UpperRoyalTower);
+			Add(new ItemKey(6, 14, 136, 177), "Letter - Aleana Boss (Stained Letter)", null, UpperRoyalTower);
+			Add(new ItemKey(6, 25, 152, 145), "Letter - Near Bottom Struggle Juggle (Mission Findings)", null, UpperRoyalTower & DoubleJumpOfNpc);
 			areaName = "Caves of Banishment (Maw)";
-			Add(new ItemKey(8, 36, 136, 145), "Journal - Lower Left Maw Caves (Naïvety)", null, LowerCavesOfBanishment);
+			Add(new ItemKey(8, 36, 136, 145), "Letter - Lower Left Maw Caves (Naïvety)", null, LowerCavesOfBanishment);
 		}
 
 		ItemLocation GetItemLocationBasedOnKeyOrRoomKey(ItemKey key)

--- a/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
+++ b/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
@@ -20,7 +20,7 @@ namespace TsRandomizer.Screens.SeedSelection
 			{ 1 << 9, new SeedOptionInfo { Name = "Stinky Maw", Description = "Require gassmask for Maw" } },
 			{ 1 << 10, new SeedOptionInfo { Name = "Gyre Archives", Description = "Gyre locations are in logic. New warps are gated by Merchant Crow and Kobo." } },
 			{ 1 << 11, new SeedOptionInfo { Name = "Cantoran", Description = "Cantoran's fight and check are available upon revisiting his room." } },
-			{ 1 << 12, new SeedOptionInfo { Name = "Lore Checks", Description = "Memories and journal entries contain items." } },
+			{ 1 << 12, new SeedOptionInfo { Name = "Lore Checks", Description = "Memories in the present and letters in the past contain items." } },
 			{ 1 << 13, new SeedOptionInfo { Name = "Damage Rando", Description = "Each orb has a high chance of having lower base damage and a low chance of having much higher base damage." } },
 		};
 

--- a/TsRandomizer/SeedOptions.cs
+++ b/TsRandomizer/SeedOptions.cs
@@ -54,7 +54,7 @@ namespace TsRandomizer
 				{"StinkyMaw", 1U << 9},
 				{"GyreArchives", 1U << 10},
 				{"Cantoran", 1U << 11},
-        {"LoreChecks", 1U << 12},
+				{"LoreChecks", 1U << 12},
 				{"DamageRando", 1U << 13 },
 				{"DeathLink", 1U << 17}
 			};


### PR DESCRIPTION
Minor description change, lore checks now describes entries in the past as "letters" to be consistent with the in-game menu.