### PR TITLE
Resolve Pyramid Pit Softlock

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -36,7 +36,7 @@ Extract the contents of the corresponding zip file to the same folder as Timespi
 * Umbra orb is randomized in even if you don't own the password
 * Achievements cannot be unlocked
 * SaveStatue inside right elevator room is disabled to prevent a softlock
-* SaveStatue down in the pit of the ancient pyramid is disabled to prevent a softlock
+* A return warp to the Pyramid entrance has been added in the Pyramid pit to prevent a softlock
 * SaveStatues in front of Temportal Gyre bosses Ifrit and Ravenlord are disabled to prevent softlocks
 * Aelana and The Maw no longer require twins to be killed before their door unlocks
 

--- a/TsRandomizer/LevelObjects/Other/GlowingFloorEvent.cs
+++ b/TsRandomizer/LevelObjects/Other/GlowingFloorEvent.cs
@@ -3,27 +3,34 @@ using Timespinner.GameObjects.BaseClasses;
 using TsRandomizer.IntermediateObjects;
 using TsRandomizer.Screens;
 
-namespace TsRandomizer.LevelObjects.ItemManipulators
+namespace TsRandomizer.LevelObjects.Other
 {
-	[TimeSpinnerType("Timespinner.GameObjects.NPCs.MessengerNPC")]
+	[TimeSpinnerType("Timespinner.GameObjects.Events.EnvironmentPrefabs.L11_Lab.EnvPrefabLabVilete")]
 	// ReSharper disable once UnusedMember.Global
-	class PanoNpc : LevelObject
+	class GlowingFloorEvent : LevelObject
 	{
 		bool teleportEnabled = false;
 		bool teleportTriggered = false;
-		public PanoNpc(Mobile typedObject) : base(typedObject)
+		public GlowingFloorEvent(Mobile typedObject) : base(typedObject)
 		{
+			if (Dynamic.Level.ID != 16)
+				return;
+			Dynamic._textPromptOffsetX = -20;
+			Dynamic._textPromptText = "Exit the pyramid";
 		}
 
 		protected override void OnUpdate(GameplayScreen gameplayScreen)
 		{
+			if (Dynamic.Level.ID != 16)
+				return;
 			if (teleportTriggered)
 				return;
-			if (Dynamic.IsTalking)
+			if (Scripts.Count != 0)
 			{
 				teleportEnabled = true;
+				Scripts.Clear();
 			}
-			if (teleportEnabled && Scripts.Count == 0) // Conversation triggered and finished
+			if (teleportEnabled && Scripts.Count == 0)
 			{
 				LevelReflected.JukeBox.StopSong();
 				LevelReflected.RequestChangeLevel(new LevelChangeRequest

--- a/TsRandomizer/LevelObjects/Other/PanoNPC.cs
+++ b/TsRandomizer/LevelObjects/Other/PanoNPC.cs
@@ -1,0 +1,43 @@
+﻿using Timespinner.GameAbstractions.Gameplay;
+using Timespinner.GameObjects.BaseClasses;
+using TsRandomizer.IntermediateObjects;
+using TsRandomizer.Screens;
+
+namespace TsRandomizer.LevelObjects.ItemManipulators
+{
+	[TimeSpinnerType("Timespinner.GameObjects.NPCs.MessengerNPC")]
+	// ReSharper disable once UnusedMember.Global
+	class PanoNpc : LevelObject
+	{
+		bool teleportEnabled = false;
+		bool teleportTriggered = false;
+		public PanoNpc(Mobile typedObject) : base(typedObject)
+		{
+		}
+
+		protected override void OnUpdate(GameplayScreen gameplayScreen)
+		{
+			if (teleportTriggered)
+				return;
+			if (Dynamic.IsTalking)
+			{
+				teleportEnabled = true;
+			}
+			if (teleportEnabled && Scripts.Count == 0) // Conversation triggered and finished
+			{
+				LevelReflected.JukeBox.StopSong();
+				LevelReflected.RequestChangeLevel(new LevelChangeRequest
+				{
+					LevelID = 15,
+					RoomID = 0,
+					IsUsingWarp = true,
+					IsUsingWhiteFadeOut = true,
+					FadeInTime = 0.5f,
+					FadeOutTime = 0.25f
+				}); // Return to Pyramid start
+				LevelReflected.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Level15);
+				teleportTriggered = true;
+			}
+		}
+	}
+}

--- a/TsRandomizer/LevelObjects/Other/SaveStatue.cs
+++ b/TsRandomizer/LevelObjects/Other/SaveStatue.cs
@@ -23,7 +23,6 @@ namespace TsRandomizer.LevelObjects.Other
 				return;
 
 			if ((Level.ID != 2 || Level.RoomID != 20) // Right side libarary elevator room
-				&& (Level.ID != 16 || Level.RoomID != 21) // Pyramid pit
 				&& (Level.ID != 14 || Level.RoomID != 8) // Ravenlord
 				&& (Level.ID != 14 || Level.RoomID != 6))  // Ifrit
 				return;

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -7,6 +7,7 @@ using Timespinner.Core.Specifications;
 using Timespinner.GameAbstractions.Gameplay;
 using Timespinner.GameAbstractions.Inventory;
 using Timespinner.GameObjects.BaseClasses;
+using Timespinner.GameObjects.Events.EnvironmentPrefabs;
 using Timespinner.GameObjects.Events;
 using TsRandomizer.Archipelago;
 using TsRandomizer.Extensions;
@@ -25,7 +26,7 @@ namespace TsRandomizer.LevelObjects
 		static readonly Type GyreType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.Doors.GyrePortalEvent");
 		static readonly Type NelisteNpcType = TimeSpinnerType.Get("Timespinner.GameObjects.NPCs.AstrologerNPC");
 		static readonly Type YorneNpcType = TimeSpinnerType.Get("Timespinner.GameObjects.NPCs.YorneNPC");
-		static readonly Type PanoNpcType = TimeSpinnerType.Get("Timespinner.GameObjects.NPCs.MessengerNPC");
+		static readonly Type GlowingFloorEventType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.EnvironmentPrefabs.L11_Lab.EnvPrefabLabVilete");
 		static readonly Type PedestalType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.Treasure.OrbPedestalEvent");
 		static readonly Type LakeVacuumLevelEffectType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.LevelEffects.LakeVacuumLevelEffect");
 
@@ -289,9 +290,9 @@ namespace TsRandomizer.LevelObjects
 				level.GameSave.SetValue("IsEndingCDCleared", true);
 			}));
 			RoomTriggers.Add(new RoomTrigger(16, 21, (level, itemLocation, seedOptions, screenManager) => {
-				// Spawn Pano to give a soft-lock exit warp
-				if (((Dictionary<int, NPCBase>)level.AsDynamic()._npcs).Values.Any(npc => npc.GetType() == PanoNpcType)) return;
-				SpawnPano(level);
+				// Spawn glowing floor event to give a soft-lock exit warp
+				if (((Dictionary<int, NPCBase>)level.AsDynamic()._npcs).Values.Any(npc => npc.GetType() == GlowingFloorEventType)) return;
+				SpawnGlowingFloor(level);
 			}));
 			RoomTriggers.Add(new RoomTrigger(16, 27, (level, itemLocation, seedOptions, screenManager) =>
 			{
@@ -428,12 +429,12 @@ namespace TsRandomizer.LevelObjects
 			level.AsDynamic().RequestAddObject(neliste);
 		}
 
-		static void SpawnPano(Level level)
+		static void SpawnGlowingFloor(Level level)
 		{
 			var position = new Point(100, 195);
-			var pano = (NPCBase)PanoNpcType.CreateInstance(false, level, position, -1, new ObjectTileSpecification() { IsFlippedHorizontally = true });
+			var floor = GlowingFloorEventType.CreateInstance(false, level, position, -1, new ObjectTileSpecification(), EEnvironmentPrefabType.L0_TableCake);
 
-			level.AsDynamic().RequestAddObject(pano);
+			level.AsDynamic().RequestAddObject(floor);
 		}
 
 		static void SpawnYorne(Level level)

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -25,7 +25,8 @@ namespace TsRandomizer.LevelObjects
 		static readonly Type GyreType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.Doors.GyrePortalEvent");
 		static readonly Type NelisteNpcType = TimeSpinnerType.Get("Timespinner.GameObjects.NPCs.AstrologerNPC");
 		static readonly Type YorneNpcType = TimeSpinnerType.Get("Timespinner.GameObjects.NPCs.YorneNPC");
-		static readonly Type PedistalType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.Treasure.OrbPedestalEvent");
+		static readonly Type PanoNpcType = TimeSpinnerType.Get("Timespinner.GameObjects.NPCs.MessengerNPC");
+		static readonly Type PedestalType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.Treasure.OrbPedestalEvent");
 		static readonly Type LakeVacuumLevelEffectType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.LevelEffects.LakeVacuumLevelEffect");
 
 		static RoomTrigger()
@@ -94,7 +95,7 @@ namespace TsRandomizer.LevelObjects
 						SpawnItemDropPickup(level, itemLocation.ItemInfo, 200, 208);
 
 				if(!seedOptions.Inverted && level.GameSave.HasCutsceneBeenTriggered("Alt3_Teleport"))
-					CreateSimpelOneWayWarp(level, 16, 12);
+					CreateSimpleOneWayWarp(level, 16, 12);
 			}));
 			RoomTriggers.Add(new RoomTrigger(7, 5, (level, itemLocation, seedOptions, screenManager) =>
 			{
@@ -138,7 +139,7 @@ namespace TsRandomizer.LevelObjects
 			{
 				if (seedOptions.Inverted || level.GameSave.HasRelic(EInventoryRelicType.PyramidsKey)) return;
 
-				CreateSimpelOneWayWarp(level, 2, 54);
+				CreateSimpleOneWayWarp(level, 2, 54);
 			}));
 			RoomTriggers.Add(new RoomTrigger(2, 54, (level, itemLocation, seedOptions, screenManager) =>
 			{
@@ -146,7 +147,7 @@ namespace TsRandomizer.LevelObjects
 				    || level.GameSave.HasRelic(EInventoryRelicType.PyramidsKey)
 					|| !level.GameSave.DataKeyBools.ContainsKey("HasUsedCityTS")) return;
 
-				CreateSimpelOneWayWarp(level, 3, 6);
+				CreateSimpleOneWayWarp(level, 3, 6);
 			}));
 			RoomTriggers.Add(new RoomTrigger(7, 30, (level, itemLocation, seedOptions, screenManager) =>
 			{
@@ -243,7 +244,7 @@ namespace TsRandomizer.LevelObjects
 				if (level.GameSave.DataKeyBools.ContainsKey("IsEndingABCleared")) return;
 
 				((Dictionary<int, GameEvent>)level.AsDynamic()._levelEvents).Values
-					.FirstOrDefault(obj => obj.GetType() == PedistalType)
+					.FirstOrDefault(obj => obj.GetType() == PedestalType)
 					?.SilentKill();
 			}));
 			RoomTriggers.Add(new RoomTrigger(8, 6, (level, itemLocation, seedOptions, screenManager) =>
@@ -281,6 +282,16 @@ namespace TsRandomizer.LevelObjects
 				if (!seedOptions.GassMaw) return;
 
 				FillRoomWithGass(level);
+			}));
+			RoomTriggers.Add(new RoomTrigger(16, 1, (level, itemLocation, seedOptions, screenManager) => {
+				// Allow the post-Nightmare chest to spawn
+				level.GameSave.SetValue("IsGameCleared", true);
+				level.GameSave.SetValue("IsEndingCDCleared", true);
+			}));
+			RoomTriggers.Add(new RoomTrigger(16, 21, (level, itemLocation, seedOptions, screenManager) => {
+				// Spawn Pano to give a soft-lock exit warp
+				if (((Dictionary<int, NPCBase>)level.AsDynamic()._npcs).Values.Any(npc => npc.GetType() == PanoNpcType)) return;
+				SpawnPano(level);
 			}));
 			RoomTriggers.Add(new RoomTrigger(16, 27, (level, itemLocation, seedOptions, screenManager) =>
 			{
@@ -365,7 +376,7 @@ namespace TsRandomizer.LevelObjects
 			levelReflected.RequestAddObject((GameEvent)orbPedestalEvent);
 		}
 
-		static void CreateSimpelOneWayWarp(Level level, int destinationLevelId, int destinationRoomId)
+		static void CreateSimpleOneWayWarp(Level level, int destinationLevelId, int destinationRoomId)
 		{
 			var dynamicLevel = level.AsDynamic();
 
@@ -415,6 +426,14 @@ namespace TsRandomizer.LevelObjects
 			var neliste = (NPCBase)NelisteNpcType.CreateInstance(false, level, position, -1, new ObjectTileSpecification());
 
 			level.AsDynamic().RequestAddObject(neliste);
+		}
+
+		static void SpawnPano(Level level)
+		{
+			var position = new Point(100, 195);
+			var pano = (NPCBase)PanoNpcType.CreateInstance(false, level, position, -1, new ObjectTileSpecification() { IsFlippedHorizontally = true });
+
+			level.AsDynamic().RequestAddObject(pano);
 		}
 
 		static void SpawnYorne(Level level)

--- a/TsRandomizer/LevelObjects/TextReplacer.cs
+++ b/TsRandomizer/LevelObjects/TextReplacer.cs
@@ -11,6 +11,10 @@ namespace TsRandomizer.LevelObjects
 
 		static TextReplacer()
 	    {
+			TextReplacers.Add(new TextReplacer(16, 21, (level, itemLocations, options) => {
+				TimeSpinnerGame.Localizer.OverrideKey("cs_pro_car_07",
+					"I can use some of my power to help warp you back out of here.");
+			}));
 			TextReplacers.Add(new TextReplacer(16,26, (level, itemLocations, options) =>
 			{
 				var concussions = level.GameSave.GetConcussionCount();

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -187,7 +187,7 @@ namespace TsRandomizer.Randomisation
 
 		static int CalculateCapacity(SeedOptions options)
 		{
-			var capacity = 165;
+			var capacity = 166;
 
 			if (options.DownloadableItems)
 				capacity += 14;
@@ -403,8 +403,9 @@ namespace TsRandomizer.Randomisation
 			areaName = "Ancient Pyramid";
 			Add(new ItemKey(16, 14, 312, 192), "Why not it's right there", ItemProvider.Get(EItemType.MaxSand), LeftPyramid);
 			Add(new ItemKey(16, 3, 88, 192), "Conviction guarded room", ItemProvider.Get(EItemType.MaxHP), LeftPyramid);
-			Add(new ItemKey(16, 22, 200, 192), "Pit secret room", ItemProvider.Get(EItemType.MaxAura), Nightmare & OculusRift); //only requires LeftPyramid to reach but Nightmate to escape
-			Add(new ItemKey(16, 16, 1512, 144), "Regret chest", ItemProvider.Get(EInventoryRelicType.EssenceOfSpace), Nightmare & OculusRift); //only requires LeftPyramid to reach but Nightmate to escape	
+			Add(new ItemKey(16, 22, 200, 192), "Pit secret room", ItemProvider.Get(EItemType.MaxAura), LeftPyramid & OculusRift);
+			Add(new ItemKey(16, 16, 1512, 144), "Regret chest", ItemProvider.Get(EInventoryRelicType.EssenceOfSpace), LeftPyramid & OculusRift);
+			Add(new ItemKey(16, 5, 136, 192), "Nightmare Door chest", ItemProvider.Get(EInventoryEquipmentType.SelenBangle), Nightmare);
 		}
 
 		void AddGyreItemLocations()

--- a/TsRandomizer/Randomisation/ItemPlacers/ItemLocationRandomizer.cs
+++ b/TsRandomizer/Randomisation/ItemPlacers/ItemLocationRandomizer.cs
@@ -44,7 +44,6 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 
 			itemsToAddToGame = new[]
 			{
-				ItemInfoProvider.Get(EInventoryEquipmentType.SelenBangle),
 				ItemInfoProvider.Get(EInventoryEquipmentType.GlassPumpkin),
 				ItemInfoProvider.Get(EInventoryEquipmentType.EternalCoat),
 				ItemInfoProvider.Get(EInventoryEquipmentType.EternalTiara),

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Commands\GiveRelicCommand.cs" />
     <Compile Include="Commands\TeleportCommand.cs" />
     <Compile Include="LevelObjects\ItemManipulators\JournalMemoryEvent+JournalLetterEvent.cs" />
+    <Compile Include="LevelObjects\Other\PanoNPC.cs" />
     <Compile Include="Randomisation\HintGenerator.cs" />
     <Compile Include="Screens\GameConsole.cs" />
     <Compile Include="Archipelago\DeathLinker.cs" />

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -106,7 +106,7 @@
     <Compile Include="Commands\GiveRelicCommand.cs" />
     <Compile Include="Commands\TeleportCommand.cs" />
     <Compile Include="LevelObjects\ItemManipulators\JournalMemoryEvent+JournalLetterEvent.cs" />
-    <Compile Include="LevelObjects\Other\PanoNPC.cs" />
+    <Compile Include="LevelObjects\Other\GlowingFloorEvent.cs" />
     <Compile Include="Randomisation\HintGenerator.cs" />
     <Compile Include="Screens\GameConsole.cs" />
     <Compile Include="Archipelago\DeathLinker.cs" />


### PR DESCRIPTION
Per discussion in the Discord, this adds a warp in the pyramid pit save room that returns to the beginning of the Pyramid.

This allows:
- Lightwall climb anti-frustration, by allowing aura to be refilled at the save point between failed attempts, as you would in vanilla
- More interesting routing by allowing the two paths in the regret chest to potentially (but rarely) be in logic (on seeds with only dash/double jump up to that point)
In addition, to complete the pyramid/the last missing chest in the randomizer, the Nightmare chest has been added. It cannot contain a progression item at this time, but may provide a last minute boon for the final boss, such as a Radiant or Empire orb