### PR TITLE
Fix Warp Shards in Default Inventory depending on secondary flag

### DIFF
--- a/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
+++ b/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
@@ -27,7 +27,7 @@ namespace TsRandomizer.LevelObjects.Other
 			PlayerInventory inventory = Dynamic._level.GameSave.Inventory;
 
 			// Only sell warp shards if Pyramid Key is aquired (and allowed in settings)
-			if (gameSettings.ShopWarpShards.Value && inventory.RelicInventory.IsRelicActive(EInventoryRelicType.PyramidsKey))
+			if ((gameSettings.ShopWarpShards.Value || fillType == "Default") && inventory.RelicInventory.IsRelicActive(EInventoryRelicType.PyramidsKey))
 				merchandiseInventory.AddItem(EInventoryUseItemType.WarpCard);
 
 			if (fillType == "Empty")


### PR DESCRIPTION
Fixes warp shards not being sold when the Default fill was on