### PR TITLE
Damage rando v2

### DIFF
--- a/TsRandomizer/LevelObjects/LevelObject.cs
+++ b/TsRandomizer/LevelObjects/LevelObject.cs
@@ -138,7 +138,7 @@ namespace TsRandomizer.LevelObjects
 			var lunais = level.MainHero;
 			if (roomChanged || newItems.Any()) AwardFirstFrameItem(itemsDictionary, lunais);
 
-			if (gameSettings.DamageRando.Value)
+			if (gameSettings.DamageRando.Value != "Off")
 				OrbDamageManager.UpdateOrbDamage(level.GameSave, level.MainHero);
 
 			KnownItemIds.Clear();
@@ -151,7 +151,7 @@ namespace TsRandomizer.LevelObjects
 				level.GameSave.AddConcussion();
 		}
 
-		static void OnChangeRoom(Level level, ItemLocationMap itemLocations, SeedOptions seedOptions, 
+		static void OnChangeRoom(Level level, ItemLocationMap itemLocations, SeedOptions seedOptions,
 			SettingCollection gameSettings, ScreenManager screenManager)
 		{
 #if DEBUG

--- a/TsRandomizer/Screens/GameplayScreen.cs
+++ b/TsRandomizer/Screens/GameplayScreen.cs
@@ -88,8 +88,10 @@ namespace TsRandomizer.Screens
 
 			ItemManipulator.Initialize(ItemLocations);
 
-			if (settings.DamageRando.Value)
-				OrbDamageManager.PopulateOrbLookups(Level.GameSave);
+			if (settings.DamageRando.Value != "Off")
+				OrbDamageManager.PopulateOrbLookups(Level.GameSave, settings.DamageRando.Value, settings.DamageRandoOverrides.Value);
+
+
 
 			if (seedOptions.Archipelago)
 			{

--- a/TsRandomizer/Settings/GameSettingObjects/DamageRandoOverridesSetting.cs
+++ b/TsRandomizer/Settings/GameSettingObjects/DamageRandoOverridesSetting.cs
@@ -2,53 +2,25 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Timespinner.GameAbstractions.Inventory;
+using TsRandomizer.Randomisation;
 
 namespace TsRandomizer.Settings.GameSettingObjects
 {
-	public class OrbDamageOdds
+	public class DamageRandoOverridesSetting : GameSetting<Dictionary<string, OrbDamageOdds>>
 	{
-		public enum OrbDamageModifier
+		private static Dictionary<string, OrbDamageOdds> GetDefaultOrbOdds()
 		{
-			Minus,
-			Normal,
-			Plus
-		}
-
-		public EInventoryOrbType orbType;
-		public int MinusOdds { get; set; }
-		public int NormalOdds { get; set; }
-		public int PlusOdds { get; set; }
-		public OrbDamageModifier GetModifier(Random random)
-		{
-			try
-			{
-				int sumOfWeights = MinusOdds + PlusOdds + NormalOdds;
-				int choice = random.Next(1, sumOfWeights);
-				switch (choice)
-				{
-					case int o when (o <= MinusOdds):
-						return OrbDamageModifier.Minus;
-					case int o when (o > MinusOdds + NormalOdds):
-						return OrbDamageModifier.Plus;
-					default:
-						return OrbDamageModifier.Normal;
-				}
-			}
-			catch
-			{
-				return OrbDamageModifier.Normal;
-			}
-		}
-	}
-
-	public class DamageRandoOverridesSetting : GameSetting<List<OrbDamageOdds>>
-	{
-		private static List<OrbDamageOdds> GetDefaultOrbOdds()
-		{
-			List<OrbDamageOdds> defaultOdds = new List<OrbDamageOdds>();
+			Dictionary<string, OrbDamageOdds> defaultOdds =
+				new Dictionary<string, OrbDamageOdds>();
 			foreach (EInventoryOrbType orbType in Enum.GetValues(typeof(EInventoryOrbType)))
 			{
-				defaultOdds.Add(new OrbDamageOdds { MinusOdds = 1, NormalOdds = 1, PlusOdds = 1, orbType = orbType });
+				if (orbType != EInventoryOrbType.Monske && orbType != EInventoryOrbType.None)
+					defaultOdds.Add(orbType.ToString(), new OrbDamageOdds
+					{
+						MinusOdds = 1,
+						NormalOdds = 1,
+						PlusOdds = 1,
+					});
 			}
 			return defaultOdds;
 		}

--- a/TsRandomizer/Settings/GameSettingObjects/DamageRandoOverridesSetting.cs
+++ b/TsRandomizer/Settings/GameSettingObjects/DamageRandoOverridesSetting.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Timespinner.GameAbstractions.Inventory;
+
+namespace TsRandomizer.Settings.GameSettingObjects
+{
+	public class OrbDamageOdds
+	{
+		public enum OrbDamageModifier
+		{
+			Minus,
+			Normal,
+			Plus
+		}
+
+		public EInventoryOrbType orbType;
+		public int MinusOdds { get; set; }
+		public int NormalOdds { get; set; }
+		public int PlusOdds { get; set; }
+		public OrbDamageModifier GetModifier(Random random)
+		{
+			try
+			{
+				int sumOfWeights = MinusOdds + PlusOdds + NormalOdds;
+				int choice = random.Next(1, sumOfWeights);
+				switch (choice)
+				{
+					case int o when (o <= MinusOdds):
+						return OrbDamageModifier.Minus;
+					case int o when (o > MinusOdds + NormalOdds):
+						return OrbDamageModifier.Plus;
+					default:
+						return OrbDamageModifier.Normal;
+				}
+			}
+			catch
+			{
+				return OrbDamageModifier.Normal;
+			}
+		}
+	}
+
+	public class DamageRandoOverridesSetting : GameSetting<List<OrbDamageOdds>>
+	{
+		private static List<OrbDamageOdds> GetDefaultOrbOdds()
+		{
+			List<OrbDamageOdds> defaultOdds = new List<OrbDamageOdds>();
+			foreach (EInventoryOrbType orbType in Enum.GetValues(typeof(EInventoryOrbType)))
+			{
+				defaultOdds.Add(new OrbDamageOdds { MinusOdds = 1, NormalOdds = 1, PlusOdds = 1, orbType = orbType });
+			}
+			return defaultOdds;
+		}
+
+		public DamageRandoOverridesSetting(string name, string description, bool canBeChangedInGame = false)
+				: base(name, description, GetDefaultOrbOdds(), canBeChangedInGame)
+		{
+
+		}
+
+		[JsonConstructor]
+		public DamageRandoOverridesSetting()
+		{
+		}
+
+		public override void ToggleValue()
+		{
+
+		}
+	}
+}

--- a/TsRandomizer/Settings/GameSettingsLoader.cs
+++ b/TsRandomizer/Settings/GameSettingsLoader.cs
@@ -23,6 +23,7 @@ namespace TsRandomizer.Settings
 				if (!File.Exists(file))
 				{
 					settings = new SettingCollection();
+					Console.WriteLine("Settings file not found: " + file);
 				}
 				else
 				{
@@ -31,12 +32,11 @@ namespace TsRandomizer.Settings
 					settings = FromJson(settingsString);
 				}
 
-				Console.WriteLine("Settings file not found: " + file);
 			}
 			catch
 			{
 				Console.WriteLine("Error loading settings from " + SettingSubFolderName);
-
+				BackupMalformedSettingsFile();
 				settings = new SettingCollection();
 			}
 
@@ -61,6 +61,19 @@ namespace TsRandomizer.Settings
 			{
 				Console.WriteLine($"Error writing settings: {e}");
 			}
+		}
+
+		public static void BackupMalformedSettingsFile()
+		{
+			try
+			{
+				File.Copy(GetSettingsFilePath(), $"{SettingSubFolderName}/settings_ERROR.json");
+			}
+			catch
+			{
+				// tough luck man idk
+			}
+
 		}
 
 		public static SettingCollection LoadSettingsFromSlotData(Dictionary<string, object> slotData)
@@ -156,7 +169,6 @@ namespace TsRandomizer.Settings
 				.FirstOrDefault() ?? "settings.json";
 		}
 
-
 		internal static SettingCollection FromJson(string json)
 		{
 			try
@@ -172,7 +184,7 @@ namespace TsRandomizer.Settings
 			catch
 			{
 				Console.WriteLine("Error loading settings from " + json);
-
+				BackupMalformedSettingsFile();
 				return new SettingCollection();
 			}
 		}

--- a/TsRandomizer/Settings/GameSettingsLoader.cs
+++ b/TsRandomizer/Settings/GameSettingsLoader.cs
@@ -23,14 +23,14 @@ namespace TsRandomizer.Settings
 				if (!File.Exists(file))
 				{
 					settings = new SettingCollection();
-				} 
-				else 
+				}
+				else
 				{
 					var settingsString = File.ReadAllText(file);
 
 					settings = FromJson(settingsString);
 				}
-				
+
 				Console.WriteLine("Settings file not found: " + file);
 			}
 			catch
@@ -67,8 +67,6 @@ namespace TsRandomizer.Settings
 		{
 			var settings = LoadSettingsFromFile();
 
-			if (slotData.TryGetValue("DamageRando", out var damageRando))
-				settings.DamageRando.Value = IsTrue(damageRando);
 			if (slotData.TryGetValue("ShopWarpShards", out var shopWarpShards))
 				settings.ShopWarpShards.Value = IsTrue(shopWarpShards);
 			if (slotData.TryGetValue("ShopMultiplier", out var shopMultiplier))
@@ -99,6 +97,40 @@ namespace TsRandomizer.Settings
 
 				settings.ShopFill.Value = enumValue;
 			}
+			if (slotData.TryGetValue("DamageRando", out var damageRando))
+			{
+				var value = ToInt(damageRando);
+				string enumValue;
+
+				switch (value)
+				{
+					case 1:
+						enumValue = "All Nerfs";
+						break;
+
+					case 2:
+						enumValue = "Mostly Nerfs";
+						break;
+
+					case 3:
+						enumValue = "Balanced";
+						break;
+
+					case 4:
+						enumValue = "Mostly Buffs";
+						break;
+
+					case 5:
+						enumValue = "All Buffs";
+						break;
+
+					default:
+						enumValue = "Off";
+						break;
+				}
+				settings.DamageRando.Value = enumValue;
+			}
+
 
 			return settings;
 		}
@@ -107,7 +139,7 @@ namespace TsRandomizer.Settings
 		{
 			try
 			{
-				if (!Directory.Exists(SettingSubFolderName)) 
+				if (!Directory.Exists(SettingSubFolderName))
 					Directory.CreateDirectory(SettingSubFolderName);
 			}
 			catch

--- a/TsRandomizer/Settings/GameSettingsLoader.cs
+++ b/TsRandomizer/Settings/GameSettingsLoader.cs
@@ -137,6 +137,10 @@ namespace TsRandomizer.Settings
 						enumValue = "All Buffs";
 						break;
 
+					case 6:
+						enumValue = "Manual";
+						break;
+
 					default:
 						enumValue = "Off";
 						break;

--- a/TsRandomizer/Settings/SettingCollection.cs
+++ b/TsRandomizer/Settings/SettingCollection.cs
@@ -30,11 +30,11 @@ namespace TsRandomizer.Settings
 		};
 
 		public SpecificValuesGameSetting DamageRando = new SpecificValuesGameSetting("Damage Randomizer",
-			"Randomly nerfs and buffs orbs, spells, and some rings.",
-			new List<string> { "Off", "All Nerfs", "Mostly Nerfs", "Balanced", "Mostly Buffs", "All Buffs" });
+			"Randomly nerfs and buffs orbs, spells, and some rings. \"Manual\" requires editing the randomizer settings file.",
+			new List<string> { "Off", "All Nerfs", "Mostly Nerfs", "Balanced", "Mostly Buffs", "All Buffs", "Manual" });
 
 		public DamageRandoOverridesSetting DamageRandoOverrides = new DamageRandoOverridesSetting("Damage Randomizer Overrides",
-			"Overrides the odds for each orb to be nerfed or buffed. Only editable from the file.");
+			"Overrides the odds for each orb to be nerfed or buffed. Only editable from the file, so you shouldn't even be seeing this text.");
 
 		public SpecificValuesGameSetting ShopFill = new SpecificValuesGameSetting("Shop Inventory",
 			"Sets the items for sale in Merchant Crow's shops. Options: [Default,Random,Vanilla,Empty]",

--- a/TsRandomizer/Settings/SettingCollection.cs
+++ b/TsRandomizer/Settings/SettingCollection.cs
@@ -31,7 +31,7 @@ namespace TsRandomizer.Settings
 
 		public SpecificValuesGameSetting DamageRando = new SpecificValuesGameSetting("Damage Randomizer",
 			"Randomly nerfs and buffs orbs, spells, and some rings. \"Manual\" requires editing the randomizer settings file.",
-			new List<string> { "Off", "All Nerfs", "Mostly Nerfs", "Balanced", "Mostly Buffs", "All Buffs", "Manual" });
+			new List<string> { "Off", "All Nerfs", "Mostly Nerfs", "Balanced", "Mostly Buffs", "All Buffs", "Manual" }, "Off");
 
 		public DamageRandoOverridesSetting DamageRandoOverrides = new DamageRandoOverridesSetting("Damage Randomizer Overrides",
 			"Overrides the odds for each orb to be nerfed or buffed. Only editable from the file, so you shouldn't even be seeing this text.");

--- a/TsRandomizer/Settings/SettingCollection.cs
+++ b/TsRandomizer/Settings/SettingCollection.cs
@@ -7,11 +7,11 @@ namespace TsRandomizer.Settings
 	public class SettingCollection
 	{
 		public static readonly GameSettingCategoryInfo[] Categories = {
-			new GameSettingCategoryInfo { Name = "Stats", Description = "Settings related to player stat scaling.", 
+			new GameSettingCategoryInfo { Name = "Stats", Description = "Settings related to player stat scaling.",
 				SettingsPerCategory = new List<Func<SettingCollection, GameSetting>> {
 					s => s.DamageRando
 				}},
-			new GameSettingCategoryInfo { Name = "Loot", Description = "Settings related to shop inventory and loot.", 
+			new GameSettingCategoryInfo { Name = "Loot", Description = "Settings related to shop inventory and loot.",
 				SettingsPerCategory = new List<Func<SettingCollection, GameSetting>> {
 					s => s.ShopFill, s => s.ShopMultiplier, s => s.ShopWarpShards
 				}},
@@ -29,8 +29,12 @@ namespace TsRandomizer.Settings
 				}}
 		};
 
-		public OnOffGameSetting DamageRando = new OnOffGameSetting("Damage Randomizer",
-			"Adds a high chance to make orb damage very low, and a low chance to make orb damage very, very high", false);
+		public SpecificValuesGameSetting DamageRando = new SpecificValuesGameSetting("Damage Randomizer",
+			"Randomly nerfs and buffs orbs, spells, and some rings.",
+			new List<string> { "Off", "All Nerfs", "Mostly Nerfs", "Balanced", "Mostly Buffs", "All Buffs" });
+
+		public DamageRandoOverridesSetting DamageRandoOverrides = new DamageRandoOverridesSetting("Damage Randomizer Overrides",
+			"Overrides the odds for each orb to be nerfed or buffed. Only editable from the file.");
 
 		public SpecificValuesGameSetting ShopFill = new SpecificValuesGameSetting("Shop Inventory",
 			"Sets the items for sale in Merchant Crow's shops. Options: [Default,Random,Vanilla,Empty]",

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -222,6 +222,7 @@
     <Compile Include="Screens\SeedSelection\SeedOptionsCollection.cs" />
     <Compile Include="Screens\SeedSelection\SeedOptionsMenuScreen.cs" />
     <Compile Include="Screens\GameSettingsScreen.cs" />
+    <Compile Include="Settings\GameSettingObjects\DamageRandoOverridesSetting.cs" />
     <Compile Include="Settings\GameSettingObjects\NumberGameSetting.cs" />
     <Compile Include="Settings\GameSettingObjects\OnOffGameSetting.cs" />
     <Compile Include="Settings\GameSettingObjects\ColorGameSetting.cs" />


### PR DESCRIPTION
- Added more options for damage rando
- - "Mostly Nerfed" is the old damage rando
- Added "Manual" setting for users to update settings.json to set their own +/- odds per orb
- Added new hidden DamageRandoOverrides setting that is only editable via editing settings.json manually
- - DamageRandoOverrides defaults to the equivalent of the "Balanced" damage rando setting
- Added feature where a malformed settings file will be backed up in the settings folder so when it's overridden by defaults no data is lost but the game doesn't crash
- Flame Orb (+) was still pretty (yawn) so I buffed it again, mostly to make Pyro Ring (+) really cool