### PR TITLE
Add item drop journal visibility setting

### DIFF
--- a/TsRandomizer/Randomisation/BestiaryManager.cs
+++ b/TsRandomizer/Randomisation/BestiaryManager.cs
@@ -23,8 +23,13 @@ namespace TsRandomizer.Randomisation
 					level.GameSave.SetValue(string.Format(bestiaryEntry.Key.Replace("Enemy_", "KILL_")), 1);
 				}
 
+				int dropSlot = 0;
 				foreach (var loot in bestiaryEntry.LootTable)
 				{
+					if (gameSettings.ShowDrops.Value)
+					{
+						level.GameSave.SetValue(string.Format(bestiaryEntry.Key.Replace("Enemy_", "DROP_" + dropSlot + "_")), true);
+					}
 					if (gameSettings.LootPool.Value == "Random")
 					{
 						var item = Helper.GetAllLoot().SelectRandom(random);
@@ -40,6 +45,7 @@ namespace TsRandomizer.Randomisation
 						loot.Item = (int)EInventoryUseItemType.PlaceHolderItem1;
 						loot.Category = (int)EInventoryCategoryType.UseItem;
 					}
+					dropSlot++;
 				}
 			}
 		}

--- a/TsRandomizer/Settings/GameSettingsLoader.cs
+++ b/TsRandomizer/Settings/GameSettingsLoader.cs
@@ -183,6 +183,8 @@ namespace TsRandomizer.Settings
 
 			if (slotData.TryGetValue("ShowBestiary", out var showBestiary))
 				settings.ShowBestiary.Value = IsTrue(showBestiary);
+			if (slotData.TryGetValue("ShowDrops", out var showDrops))
+				settings.ShowDrops.Value = IsTrue(showDrops);
 			if (slotData.TryGetValue("DeathLink", out var deathLink))
 				settings.DeathLink.Value = IsTrue(deathLink);
 

--- a/TsRandomizer/Settings/SettingCollection.cs
+++ b/TsRandomizer/Settings/SettingCollection.cs
@@ -29,7 +29,7 @@ namespace TsRandomizer.Settings
 				}},
 			new GameSettingCategoryInfo { Name = "Other", Description = "Miscellaneous settings",
 				SettingsPerCategory = new List<Func<SettingCollection, GameSetting>> {
-					s => s.ShowBestiary
+					s => s.ShowBestiary, s => s.ShowDrops
 				}}
 		};
 
@@ -42,6 +42,9 @@ namespace TsRandomizer.Settings
 
 		public OnOffGameSetting ShowBestiary = new OnOffGameSetting("Show Bestiary",
 			"All bestiary entries in the journal are visible by default.", false, false);
+
+		public OnOffGameSetting ShowDrops = new OnOffGameSetting("Show Enemy Drops",
+			"All item drops in the bestiary are visible by default.", false, false);
 
 		public SpecificValuesGameSetting LootPool = new SpecificValuesGameSetting("Loot Pool",
 			"Sets which items enemies will drop: [Vanilla, Random, Empty]",


### PR DESCRIPTION
This PR adds a setting to show the items dropped by an enemy before they are dropped, as a companion to the setting that toggles bestiary entry visibility.

![image](https://user-images.githubusercontent.com/32756996/169179818-a9fdf15c-b503-4a9b-8056-bb088af4a003.png)
