### PR TITLE
Make Merchant Crow Random per seed

### DIFF
--- a/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
+++ b/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
@@ -19,7 +19,7 @@ namespace TsRandomizer.LevelObjects.Other
 
 		protected override void Initialize(SeedOptions options)
 		{
-			var gameSettings = ((GameSave)Dynamic._level.GameSave).GetSettings();
+			var gameSettings = Level.GameSave.GetSettings();
 			var fillType = gameSettings.ShopFill.Value;
 			if (fillType == "Vanilla")
 				return;
@@ -37,7 +37,7 @@ namespace TsRandomizer.LevelObjects.Other
 			}
 			if (fillType == "Random")
 			{
-				var random = new Random((int)options.Flags);
+				var random = new Random((int)Level.GameSave.GetSeed().Value.Id);
 				for (var i = 0; i < 8; i++)
 				{
 					var item = Helper.GetAllLoot().SelectRandom(random);


### PR DESCRIPTION
Fixes issue where Merchant Crow shop was only unique per flag set and not per seed.