### PR TITLE
Add individual settings menu resets

### DIFF
--- a/TsRandomizer/Screens/GameSettingsScreen.cs
+++ b/TsRandomizer/Screens/GameSettingsScreen.cs
@@ -100,30 +100,10 @@ namespace TsRandomizer.Screens
 
 		void OnDefaultsSelected(GameSettingCategoryInfo[] menusToClear, bool isSubmenu)
 		{
-			if (isSubmenu)
-			{
-				foreach (var category in menusToClear)
-				{
-					foreach (var settingsFunc in category.SettingsPerCategory)
-					{
-						var setting = settingsFunc(settings);
-						if (IsInGame && !setting.CanBeChangedInGame)
-							continue;
-						setting.SetDefault();
-					}
-				}
-				ResetMenu();
-				Dynamic.GoToPreviousMenuCollection();
-				return;
-			}
 			// Clear the root menu
-			if (!IsInGame)
+			if (!IsInGame && !isSubmenu)
 			{
-				var defaultSettings = new SettingCollection();
-
-				GameSettingsLoader.WriteSettingsToFile(defaultSettings);
-
-				settings = defaultSettings;
+				settings = new SettingCollection();
 			}
 			else
 			{
@@ -133,17 +113,22 @@ namespace TsRandomizer.Screens
 					{
 						var setting = settingsFunc(settings);
 
-						if(!setting.CanBeChangedInGame)
+						if(IsInGame && !setting.CanBeChangedInGame)
 							continue;
 
 						setting.SetDefault();
 					}
 				}
-
-				save.SetSettings(settings);
 			}
 
+			if (IsInGame)
+				save.SetSettings(settings);
+			else
+				GameSettingsLoader.WriteSettingsToFile(settings);
+
 			ResetMenu();
+			if (isSubmenu)
+				Dynamic.GoToPreviousMenuCollection();
 		}
 
 		void ResetMenu()

--- a/TsRandomizer/Screens/GameSettingsScreen.cs
+++ b/TsRandomizer/Screens/GameSettingsScreen.cs
@@ -91,7 +91,8 @@ namespace TsRandomizer.Screens
 		{
 			var defaultsMenu = MenuEntry.Create("Defaults", () => OnDefaultsSelected(menusToClear, isSubmenu)).AsTimeSpinnerMenuEntry();
 
-			defaultsMenu.AsDynamic().Description = "Restore all values to their defaults";
+			string menuDescription = isSubmenu ? menusToClear[0].Name : "all";
+			defaultsMenu.AsDynamic().Description = $"Restore {menuDescription} settings to their defaults";
 			defaultsMenu.AsDynamic().IsCenterAligned = false;
 
 			return defaultsMenu;

--- a/TsRandomizer/Screens/GameSettingsScreen.cs
+++ b/TsRandomizer/Screens/GameSettingsScreen.cs
@@ -107,6 +107,8 @@ namespace TsRandomizer.Screens
 					foreach (var settingsFunc in category.SettingsPerCategory)
 					{
 						var setting = settingsFunc(settings);
+						if (IsInGame && !setting.CanBeChangedInGame)
+							continue;
 						setting.SetDefault();
 					}
 				}

--- a/TsRandomizer/Screens/GameSettingsScreen.cs
+++ b/TsRandomizer/Screens/GameSettingsScreen.cs
@@ -203,6 +203,9 @@ namespace TsRandomizer.Screens
 			{
 				// Currently using quest layout for most, other layouts may be useful for other menus
 				// Leaving as switch to easily add new menus as Memories, Letters, Files, Quests, Bestiary, Feats
+				case "Archipelago":
+					collection = Dynamic._bestiaryInventory;
+					break;
 				case "Sprite":
 					collection = Dynamic._featsInventory;
 					break;


### PR DESCRIPTION
Adds back functionality mistakenly removed in refactor https://github.com/TriumphantBass/TsRandomizer/commit/8b834a55fab367eff58bf1d980a741064096a7e2 

Allows the ability to reset the defaults for a single category without affecting values in other categories. ("Defaults" in the root still clears all)