### PR TITLE
Temporary revert of AP Settings UI cleanup due to toggle bug

### DIFF
--- a/TsRandomizer/Screens/GameSettingsScreen.cs
+++ b/TsRandomizer/Screens/GameSettingsScreen.cs
@@ -191,9 +191,6 @@ namespace TsRandomizer.Screens
 			{
 				// Currently using quest layout for most, other layouts may be useful for other menus
 				// Leaving as switch to easily add new menus as Memories, Letters, Files, Quests, Bestiary, Feats
-				case "Archipelago":
-					collection = Dynamic._bestiaryInventory;
-					break;
 				case "Sprite":
 					collection = Dynamic._featsInventory;
 					break;


### PR DESCRIPTION
Some of the bestiary entry hooks are interfering with the settings toggle for AP settings.

This reverts the UI changes to keep this page fully functional until this can be investigated further.