### PR TITLE
Make Gyre unique per seed not per flag set

### DIFF
--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -438,7 +438,7 @@ namespace TsRandomizer.LevelObjects
 			RoomTriggers.Add(new RoomTrigger(14, 11, (level, itemLocation, seedOptions, gameSettings, screenManager) => {
 				// Play Gyre music in gyre
 				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Level14);
-				level.AsDynamic().SetLevelSaveInt("GyreDungeonSeed", seedOptions.Flags.GetHashCode()); // Set Gyre enemies
+				level.AsDynamic().SetLevelSaveInt("GyreDungeonSeed", (int)level.GameSave.GetSeed().Value.Id); // Set Gyre enemies
 				BestiaryManager.RefreshBossSaveFlags(level); // Reset boss save flags cleared by Gyre portal
 			}));
 			RoomTriggers.Add(new RoomTrigger(14, 23, (level, itemLocation, seedOptions, gameSettings, screenManager) => {


### PR DESCRIPTION
Fixes issue similar to the shop where the gyre layout was the same per the same flag set regardless of seed.