### PR TITLE
Add Tier-Based Rarity and Other Drop Settings

### DIFF
--- a/TsRandomizer/Extensions/Helper.cs
+++ b/TsRandomizer/Extensions/Helper.cs
@@ -14,12 +14,111 @@ namespace TsRandomizer.Extensions
 				.Where(o => o != EInventoryOrbType.None && o != EInventoryOrbType.Monske)
 				.ToArray();
 		}
+		public static ELootTier LookupUseItemRarity(EInventoryUseItemType itemType)
+		{
+			switch (itemType)
+			{
+				case EInventoryUseItemType.CheveuxFeather:
+				case EInventoryUseItemType.CheveuxBreast:
+				case EInventoryUseItemType.Drumstick:
+				case EInventoryUseItemType.EelMeat:
+				case EInventoryUseItemType.Herb:
+				case EInventoryUseItemType.WyvernTail:
+				case EInventoryUseItemType.PlumpMaggot:
+				case EInventoryUseItemType.RottenTail:
+				case EInventoryUseItemType.SilverOre:
+				case EInventoryUseItemType.SirenInk:
+				case EInventoryUseItemType.PlasmaCore:
+				case EInventoryUseItemType.PlaceHolderItem1:
+					return ELootTier.Trash;
+				case EInventoryUseItemType.Potion:
+				case EInventoryUseItemType.Ether:
+				case EInventoryUseItemType.SandBottle:
+				case EInventoryUseItemType.FuturePotion:
+				case EInventoryUseItemType.FutureEther:
+				case EInventoryUseItemType.Antidote:
+				case EInventoryUseItemType.ChaosHeal:
+				case EInventoryUseItemType.Jerky:
+					return ELootTier.Common;
+				case EInventoryUseItemType.HiPotion:
+				case EInventoryUseItemType.HiSandBottle:
+				case EInventoryUseItemType.HiEther:
+				case EInventoryUseItemType.FutureHiPotion:
+				case EInventoryUseItemType.FutureHiEther:
+				case EInventoryUseItemType.FamiliarTreat:
+				case EInventoryUseItemType.OrangeJuice:
+					return ELootTier.Uncommon;
+				case EInventoryUseItemType.WarpCard:
+				case EInventoryUseItemType.CheveuxAuVin:
+				case EInventoryUseItemType.FriedCheveux:
+				case EInventoryUseItemType.Biscuit:
+				case EInventoryUseItemType.FiligreeTea:
+				case EInventoryUseItemType.MagicMarbles:
+				case EInventoryUseItemType.Spaghetti:
+				case EInventoryUseItemType.UnagiRoll:
+					return ELootTier.Rare;
+				case EInventoryUseItemType.LachiemiSun:
+				case EInventoryUseItemType.EmpressCake:
+				case EInventoryUseItemType.Casserole:
+					return ELootTier.UltraRare;
+				default:
+					return ELootTier.Uncommon;
+			}
+		}
+		public static ELootTier LookupEquipmentRarity(EInventoryEquipmentType equipmentType)
+		{
+			switch (equipmentType)
+			{
+				case EInventoryEquipmentType.OldCoat:
+				case EInventoryEquipmentType.Sunglasses:
+				case EInventoryEquipmentType.BuckleHat:
+				case EInventoryEquipmentType.MetalWristband:
+				case EInventoryEquipmentType.MidnightCloak:
+				case EInventoryEquipmentType.MotherOfPearl:
+					return ELootTier.Trash;
+				case EInventoryEquipmentType.PointyHat:
+				case EInventoryEquipmentType.AdvisorHat:
+				case EInventoryEquipmentType.AdvisorRobe:
+				case EInventoryEquipmentType.CalvaryArmor:
+				case EInventoryEquipmentType.CalvaryHelmet:
+				case EInventoryEquipmentType.CaptainsCap:
+				case EInventoryEquipmentType.CaptainsJacket:
+				case EInventoryEquipmentType.LeatherArmor:
+				case EInventoryEquipmentType.LeatherHelmet:
+					return ELootTier.Common;
+				case EInventoryEquipmentType.SecurityVisor:
+				case EInventoryEquipmentType.SecurityVest:
+				case EInventoryEquipmentType.LibrarianHat:
+				case EInventoryEquipmentType.LibrarianRobe:
+				case EInventoryEquipmentType.EngineerGoggles:
+				case EInventoryEquipmentType.SirenHairband:
+					return ELootTier.Uncommon;
+				case EInventoryEquipmentType.LabGlasses:
+				case EInventoryEquipmentType.LabCoat:
+				case EInventoryEquipmentType.LachiemCrown:
+				case EInventoryEquipmentType.LuckyCoin:
+				case EInventoryEquipmentType.DemonHorn:
+				case EInventoryEquipmentType.FiligreeClasp:
+				case EInventoryEquipmentType.VileteCrown:
+				case EInventoryEquipmentType.VileteDress:
+					return ELootTier.Rare;
+				case EInventoryEquipmentType.Pendulum:
+				case EInventoryEquipmentType.BirdStatue:
+				case EInventoryEquipmentType.DemonStole:
+				case EInventoryEquipmentType.AzureStole:
+				case EInventoryEquipmentType.EmpressCoat:
+				case EInventoryEquipmentType.NelisteEarring:
+				case EInventoryEquipmentType.ShinyRock:
+					return ELootTier.UltraRare;
+				default:
+					return ELootTier.Uncommon;
+			}
+		}
 		public static List<ItemIdentifier> GetAllLoot()
 		{
 			// Exclude unique and placeholder objects
 			var useItems = ((EInventoryUseItemType[])Enum.GetValues(typeof(EInventoryUseItemType)))
 				.Where(o => o != EInventoryUseItemType.None
-					&& o != EInventoryUseItemType.PlaceHolderItem1
 					&& o != EInventoryUseItemType.AlchemistTools
 					&& o != EInventoryUseItemType.MagicMarbles
 					&& o != EInventoryUseItemType.EssenceCrystal
@@ -41,6 +140,8 @@ namespace TsRandomizer.Extensions
 					&& o != EInventoryEquipmentType.SelenBangle
 					&& o != EInventoryEquipmentType.ShinyRock
 					&& o != EInventoryEquipmentType.GlassPumpkin
+					&& o != EInventoryEquipmentType.EternalCoat
+					&& o != EInventoryEquipmentType.EternalTiara
 					)
 				.ToArray();
 			List<ItemIdentifier> loot = new List<ItemIdentifier>();

--- a/TsRandomizer/IntermediateObjects/ItemIdentifier.cs
+++ b/TsRandomizer/IntermediateObjects/ItemIdentifier.cs
@@ -7,6 +7,14 @@ using TsRandomizer.Extensions;
 
 namespace TsRandomizer.IntermediateObjects
 {
+	public enum ELootTier
+	{
+		Trash = 16,
+		Common = 10,
+		Uncommon = 6,
+		Rare = 3,
+		UltraRare = 2,
+	}
 	public class ItemIdentifier : IEquatable<ItemIdentifier>
 	{
 		public LootType LootType { get; }

--- a/TsRandomizer/Randomisation/ItemPlacers/ItemLocationRandomizer.cs
+++ b/TsRandomizer/Randomisation/ItemPlacers/ItemLocationRandomizer.cs
@@ -74,7 +74,8 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 				ItemInfoProvider.Get(EInventoryUseItemType.ChaosHeal),
 				ItemInfoProvider.Get(EInventoryUseItemType.Antidote),
 				ItemInfoProvider.Get(EInventoryUseItemType.SandBottle),
-				ItemInfoProvider.Get(EInventoryUseItemType.HiSandBottle)
+				ItemInfoProvider.Get(EInventoryUseItemType.HiSandBottle),
+				ItemInfoProvider.Get(EInventoryUseItemType.PlaceHolderItem1) // "Nothing"/empty chest
 			};
 		}
 

--- a/TsRandomizer/Screens/SaveSelectScreen.cs
+++ b/TsRandomizer/Screens/SaveSelectScreen.cs
@@ -36,6 +36,7 @@ namespace TsRandomizer.Screens
 		public SaveSelectScreen(ScreenManager screenManager, GameScreen screen) : base(screenManager, screen)
 		{
 			var saveFileEntries = (IList)((object)Dynamic._saveFileCollection).AsDynamic().Entries;
+			TimeSpinnerGame.Localizer.OverrideKey("inv_use_PlaceHolderItem1", "Nothing");
 
 			foreach (var entry in saveFileEntries)
 			{

--- a/TsRandomizer/Settings/GameSettingsLoader.cs
+++ b/TsRandomizer/Settings/GameSettingsLoader.cs
@@ -186,7 +186,55 @@ namespace TsRandomizer.Settings
 
 				settings.LootPool.Value = enumValue;
 			}
+			if (slotData.TryGetValue("Drop Rate Category", out var dropRateCategory))
+			{
+				var value = ToInt(dropRateCategory);
+				string enumValue;
 
+				switch (value)
+				{
+					case 1:
+						enumValue = "Vanilla";
+						break;
+
+					case 2:
+						enumValue = "Random";
+						break;
+
+					case 3:
+						enumValue = "Fixed";
+						break;
+					case 0:
+					default:
+						enumValue = "Tiered";
+						break;
+				}
+
+				settings.DropRateCategory.Value = enumValue;
+			}
+			if (slotData.TryGetValue("DropRate", out var dropRate))
+				settings.DropRate.Value = ToInt(dropRate, 5);
+			if (slotData.TryGetValue("Loot Tier Distro", out var lootTierDistro))
+			{
+				var value = ToInt(lootTierDistro);
+				string enumValue;
+
+				switch (value)
+				{
+					case 1:
+						enumValue = "Full Random";
+						break;
+					case 2:
+						enumValue = "Inverted Weight";
+						break;
+					case 0:
+					default:
+						enumValue = "Default Weight";
+						break;
+				}
+
+				settings.LootTierDistro.Value = enumValue;
+			}
 			if (slotData.TryGetValue("ShowBestiary", out var showBestiary))
 				settings.ShowBestiary.Value = IsTrue(showBestiary);
 

--- a/TsRandomizer/Settings/SettingCollection.cs
+++ b/TsRandomizer/Settings/SettingCollection.cs
@@ -13,7 +13,7 @@ namespace TsRandomizer.Settings
 				}},
 			new GameSettingCategoryInfo { Name = "Loot", Description = "Settings related to shop inventory and loot.",
 				SettingsPerCategory = new List<Func<SettingCollection, GameSetting>> {
-					s => s.ShopFill, s => s.ShopMultiplier, s => s.ShopWarpShards, s => s.LootPool
+					s => s.ShopFill, s => s.ShopMultiplier, s => s.ShopWarpShards, s => s.LootPool, s => s.DropRateCategory, s => s.DropRate, s => s.LootTierDistro
 				}},
 			new GameSettingCategoryInfo { Name = "Minimap", Description = "Settings related to minimap colors.",
 				SettingsPerCategory = new List<Func<SettingCollection, GameSetting>> {
@@ -61,6 +61,16 @@ namespace TsRandomizer.Settings
 			"Sets which items enemies will drop: [Vanilla, Random, Empty]",
 			new List<string> { "Vanilla", "Random", "Empty" }, "Vanilla", true);
 
+		public SpecificValuesGameSetting DropRateCategory = new SpecificValuesGameSetting("Drop Rate Category",
+			"Sets the drop rate of enemy items [Tiered (based on item), Vanilla (based on enemy), Random (2-12%), Fixed",
+			new List<string> { "Tiered", "Vanilla", "Random", "Fixed" }, "Tiered", true);
+
+		public NumberGameSetting DropRate = new NumberGameSetting("Fixed Drop Rate",
+			"Drop rate to be used when Drop Rate Category set to 'Fixed'", 0, 100, 2.5, 5);
+
+		public SpecificValuesGameSetting LootTierDistro = new SpecificValuesGameSetting("Loot Tier Distribution",
+			"Sets how frequently items of each loot rarity tier will be assigned to a drop slot.",
+			new List<string> { "Default Weight", "Full Random", "Inverted Weight" }, "Default Weight", true);
 
 		public SpecificValuesGameSetting ShopFill = new SpecificValuesGameSetting("Shop Inventory",
 			"Sets the items for sale in Merchant Crow's shops. Options: [Default,Random,Vanilla,Empty]",


### PR DESCRIPTION
This PR includes settings that change the drop rate and frequency at which items are assigned to drop slots.

By default now, rarer items have higher drop rates *and* are less likely to be placed into drop slots.

**Drop Rate Category**
- Tiered - items are scaled to their rarity, Ultra Rare 2%, all the way to Trash 16%
- Vanilla - items inherit the odds of the slot they fill
- Random - each item is assigned the drop rate of a random tier
- Fixed - see below

**Fixed Drop Rate**
Used when drop category is "Fixed", sets all drop rates to the same value

**Loot Rarity Distribution**
- By default "Ultra Rare" items are placed into slots the least often, with "Trash" items placed the most often.
- When using Random, the behavior is the same as prior to this PR, every item is equally likely for every lslot
- When using inverted rates, ultra rare items are placed the most frequently, while trash items are the rarest

**Other Changes**
- Eternal items have been removed from the loot pool due to maintain their value as high-value checks
- "Nothing"/empty checks have been added as filler items and to the loot pool to help dillute the pool