### PR TITLE
Rename Facebook Mode

### DIFF
--- a/TsRandomizer.ItemTracker/TrackerRenderer.cs
+++ b/TsRandomizer.ItemTracker/TrackerRenderer.cs
@@ -69,7 +69,7 @@ namespace TsRandomizerItemTracker
 				DrawItem(spriteBatch, state.CelestialSash, new ItemIdentifier(EInventoryRelicType.EssenceOfSpace));
 				DrawItem(spriteBatch, state.PyramidKeys, new ItemIdentifier(EInventoryRelicType.PyramidsKey));
 				DrawItem(spriteBatch, state.WaterMask, new ItemIdentifier(EInventoryRelicType.WaterMask));
-				DrawItem(spriteBatch, state.GassMask, new ItemIdentifier(EInventoryRelicType.AirMask));
+				DrawItem(spriteBatch, state.GasMask, new ItemIdentifier(EInventoryRelicType.AirMask));
 				DrawItem(spriteBatch, state.CardA, new ItemIdentifier(EInventoryRelicType.ScienceKeycardA));
 				DrawItem(spriteBatch, state.CardB, new ItemIdentifier(EInventoryRelicType.ScienceKeycardB));
 				DrawItem(spriteBatch, state.CardC, new ItemIdentifier(EInventoryRelicType.ScienceKeycardC));

--- a/TsRandomizer.Tests/ItemLocationMapFixture.cs
+++ b/TsRandomizer.Tests/ItemLocationMapFixture.cs
@@ -45,7 +45,7 @@ namespace TsRandomizer.Tests
 			var itemLocations = new ItemLocationMap(new ItemInfoProvider(SeedOptions.None, unlockingMap), unlockingMap, SeedOptions.None);
 
 			var accessableLocations = itemLocations.GetReachableLocations(
-					Requirement.GassMask | Requirement.AntiWeed | Requirement.Swimming | Requirement.GateLakeSereneRight | Requirement.DoubleJump)
+					Requirement.GasMask | Requirement.AntiWeed | Requirement.Swimming | Requirement.GateLakeSereneRight | Requirement.DoubleJump)
 				.ToArray();
 
 			Assert.That(Contains(accessableLocations, new ItemKey(1, 18, 1320, 189))); 

--- a/TsRandomizer/ItemTracker/ItemTrackerState.cs
+++ b/TsRandomizer/ItemTracker/ItemTrackerState.cs
@@ -34,7 +34,7 @@ namespace TsRandomizer.ItemTracker
 		public bool CardE;
 		public bool CardV;
 		public bool WaterMask;
-		public bool GassMask;
+		public bool GasMask;
 		public bool PyramidKeys;
 		public bool PinkOrb;
 		public bool PinkSpell;
@@ -92,7 +92,7 @@ namespace TsRandomizer.ItemTracker
 			{new ItemIdentifier(EInventoryRelicType.ElevatorKeycard), s => s.CardE},
 			{new ItemIdentifier(EInventoryRelicType.ScienceKeycardV), s => s.CardV},
 			{new ItemIdentifier(EInventoryRelicType.WaterMask), s => s.WaterMask},
-			{new ItemIdentifier(EInventoryRelicType.AirMask), s => s.GassMask},
+			{new ItemIdentifier(EInventoryRelicType.AirMask), s => s.GasMask},
 			{new ItemIdentifier(EInventoryRelicType.PyramidsKey), s => s.PyramidKeys},
 			{new ItemIdentifier(EInventoryOrbType.Pink, EOrbSlot.Melee), s => s.PinkOrb},
 			{new ItemIdentifier(EInventoryOrbType.Pink, EOrbSlot.Spell), s => s.PinkSpell},

--- a/TsRandomizer/LevelObjects/Other/BreakableWallEvent.cs
+++ b/TsRandomizer/LevelObjects/Other/BreakableWallEvent.cs
@@ -22,7 +22,7 @@ namespace TsRandomizer.LevelObjects.Other
 
 		protected override void OnUpdate(GameplayScreen gameplayScreen)
 		{
-			if(!options.RequireEyeOrbRing)
+			if(!options.EyeSpy)
 				return;
 
 			if (!Level.GameSave.HasRing(EInventoryOrbType.Eye))

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -51,7 +51,7 @@ namespace TsRandomizer.LevelObjects
 			level.JukeBox.StopSong();
 			level.PlayCue(Timespinner.GameAbstractions.ESFX.FoleyWarpGyreIn);
 
-			if (seedOptions.GassMaw && (vanillaBossId == (int)EBossID.Maw || (vanillaBossId == (int)EBossID.FelineSentry && level.GameSave.GetSaveBool("TSRando_IsVileteSaved"))))
+			if (seedOptions.GasMaw && (vanillaBossId == (int)EBossID.Maw || (vanillaBossId == (int)EBossID.FelineSentry && level.GameSave.GetSaveBool("TSRando_IsVileteSaved"))))
 				FillRoomWithGas(level);
 
 			if (replacedBossInfo.ShouldSpawn)
@@ -188,7 +188,7 @@ namespace TsRandomizer.LevelObjects
 				SpawnBoss(level, seedOptions, TargetBossId);
 				if (level.GameSave.GetSaveBool("IsFightingBoss"))
 					return;
-				if (seedOptions.GassMaw && !level.GameSave.GetSettings().BossRando.Value)
+				if (seedOptions.GasMaw && !level.GameSave.GetSettings().BossRando.Value)
 					FillRoomWithGas(level);
 				CreateBossWarp(level, (int)EBossID.Maw);
 			}));
@@ -463,12 +463,12 @@ namespace TsRandomizer.LevelObjects
 					?.SilentKill();
 			}));
 			RoomTriggers.Add(new RoomTrigger(8, 6, (level, itemLocation, seedOptions, gameSettings, screenManager) => {
-				if (!seedOptions.GassMaw) return;
+				if (!seedOptions.GasMaw) return;
 
 				FillRoomWithGas(level);
 			}));
 			RoomTriggers.Add(new RoomTrigger(8, 13, (level, itemLocation, seedOptions, gameSettings, screenManager) => {
-				if (seedOptions.GassMaw)
+				if (seedOptions.GasMaw)
 					FillRoomWithGas(level);
 				if (!level.GameSave.GetSaveBool("TSRando_IsBossDead_Maw"))
 					return;
@@ -482,7 +482,7 @@ namespace TsRandomizer.LevelObjects
 				BestiaryManager.RefreshBossSaveFlags(level);
 			}));
 			RoomTriggers.Add(new RoomTrigger(8, 21, (level, itemLocation, seedOptions, gameSettings, screenManager) => {
-				if (seedOptions.GassMaw) FillRoomWithGas(level);
+				if (seedOptions.GasMaw) FillRoomWithGas(level);
 
 				var levelReflected = level.AsDynamic();
 				IEnumerable<Animate> eventObjects = levelReflected._levelEvents.Values;
@@ -493,7 +493,7 @@ namespace TsRandomizer.LevelObjects
 					SpawnItemDropPickup(level, itemLocation.ItemInfo, 312, 912);
 			}));
 			RoomTriggers.Add(new RoomTrigger(8, 33, (level, itemLocation, seedOptions, gameSettings, screenManager) => {
-				if (!seedOptions.GassMaw) return;
+				if (!seedOptions.GasMaw) return;
 
 				FillRoomWithGas(level);
 			}));

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -13,7 +13,7 @@ namespace TsRandomizer.Randomisation
 	class ItemLocationMap : LookupDictionary<ItemKey, ItemLocation>
 	{
 		internal R OculusRift;
-		internal R MawGassMask;
+		internal R MawGasMask;
 
 		internal Gate AccessToPast;
 		internal Gate AccessToLakeDesolation;
@@ -99,12 +99,12 @@ namespace TsRandomizer.Randomisation
 
 		void SetupGates()
 		{
-			OculusRift = (SeedOptions.RequireEyeOrbRing)
+			OculusRift = (SeedOptions.EyeSpy)
 				? R.OculusRift
 				: R.None;
 
-			MawGassMask = (SeedOptions.GassMaw)
-				? R.GassMask
+			MawGasMask = (SeedOptions.GasMaw)
+				? R.GasMask
 				: R.None;
 
 			AccessToLakeDesolation = (!SeedOptions.Inverted)
@@ -134,7 +134,7 @@ namespace TsRandomizer.Randomisation
 				| R.GateRoyalTowers
 				| R.GateCastleRamparts
 				| R.GateCastleKeep
-				| (MawGassMask & (R.GateCavesOfBanishment | R.GateMaw)
+				| (MawGasMask & (R.GateCavesOfBanishment | R.GateMaw)
 				| R.GateCavesOfBanishment & R.Swimming
 				| R.GateMaw & R.DoubleJump & R.Swimming);
 
@@ -158,7 +158,7 @@ namespace TsRandomizer.Randomisation
 			RoyalTower = (CastleKeep & R.DoubleJump) | R.GateRoyalTowers;
 			MidRoyalTower = RoyalTower & (MultipleSmallJumpsOfNpc | ForwardDashDoubleJump);
 			UpperRoyalTower = MidRoyalTower & R.DoubleJump;
-			KillMaw = (LowerLakeSirine | R.GateCavesOfBanishment | R.GateMaw) & MawGassMask;
+			KillMaw = (LowerLakeSirine | R.GateCavesOfBanishment | R.GateMaw) & MawGasMask;
 			var killTwins = CastleKeep & R.TimeStop;
 			var killAelana = UpperRoyalTower;
 
@@ -231,8 +231,8 @@ namespace TsRandomizer.Randomisation
 			Add(new ItemKey(1, 20, 168, 240), "Lake Desolation (Upper): Double jump cave floor", ItemProvider.Get(EInventoryUseItemType.FuturePotion), UpperLakeDesolation);
 			Add(new ItemKey(1, 22, 344, 160), "Lake Desolation (Upper): Sparrow chest", ItemProvider.Get(EInventoryUseItemType.FutureHiPotion), UpperLakeDesolation);
 			Add(new ItemKey(1, 18, 1320, 189), "Lake Desolation (Upper): Crash site pedestal", ItemProvider.Get(EInventoryOrbType.Moon, EOrbSlot.Melee), UpperLakeDesolation);
-			Add(new ItemKey(1, 18, 1272, 192), "Lake Desolation (Upper): Crash site chest 1", ItemProvider.Get(EInventoryEquipmentType.CaptainsCap), UpperLakeDesolation & R.GassMask & KillMaw);
-			Add(new ItemKey(1, 18, 1368, 192), "Lake Desolation (Upper): Crash site chest 2", ItemProvider.Get(EInventoryEquipmentType.CaptainsJacket), UpperLakeDesolation & R.GassMask & KillMaw);
+			Add(new ItemKey(1, 18, 1272, 192), "Lake Desolation (Upper): Crash site chest 1", ItemProvider.Get(EInventoryEquipmentType.CaptainsCap), UpperLakeDesolation & R.GasMask & KillMaw);
+			Add(new ItemKey(1, 18, 1368, 192), "Lake Desolation (Upper): Crash site chest 2", ItemProvider.Get(EInventoryEquipmentType.CaptainsJacket), UpperLakeDesolation & R.GasMask & KillMaw);
 			Add(new RoomItemKey(1, 5), "Lake Desolation: Kitty Boss", ItemProvider.Get(EInventoryOrbType.Blade, EOrbSlot.Melee), UpperLakeDesolation | LowerLakeDesolationBridge);
 			areaName = "Library";
 			Add(new ItemKey(2, 60, 328, 160), "Library: Basement", ItemProvider.Get(EItemType.MaxHP), LeftLibrary);
@@ -363,8 +363,8 @@ namespace TsRandomizer.Randomisation
 			Add(new ItemKey(8, 41, 312, 192), "Caves of Banishment (Maw): Jackpot room chest 4", ItemProvider.Get(EInventoryUseItemType.MagicMarbles), LowerCavesOfBanishment & ForwardDashDoubleJump);
 			Add(new ItemKey(8, 42, 216, 189), "Caves of Banishment (Maw): Pedestal", ItemProvider.Get(EInventoryOrbType.Wind, EOrbSlot.Melee), LowerCavesOfBanishment);
 			Add(new ItemKey(8, 15, 248, 192), "Caves of Banishment (Maw): Last chance before Maw", ItemProvider.Get(EInventoryUseItemType.SilverOre), LowerCavesOfBanishment & R.DoubleJump);
-			Add(new RoomItemKey(8, 21), "Caves of Banishment (Maw): Plasma Crystal", ItemProvider.Get(EInventoryUseItemType.RadiationCrystal), LowerCavesOfBanishment & (MawGassMask | R.ForwardDash));
-			Add(new ItemKey(8, 31, 88, 400), "Caves of Banishment (Maw): Mineshaft", ItemProvider.Get(EInventoryUseItemType.MagicMarbles), LowerCavesOfBanishment & MawGassMask);
+			Add(new RoomItemKey(8, 21), "Caves of Banishment (Maw): Plasma Crystal", ItemProvider.Get(EInventoryUseItemType.RadiationCrystal), LowerCavesOfBanishment & (MawGasMask | R.ForwardDash));
+			Add(new ItemKey(8, 31, 88, 400), "Caves of Banishment (Maw): Mineshaft", ItemProvider.Get(EInventoryUseItemType.MagicMarbles), LowerCavesOfBanishment & MawGasMask);
 			areaName = "Caves of Banishment (Sirens)";
 			Add(new ItemKey(8, 4, 664, 144), "Caves of Banishment (Sirens): Wyvern room", ItemProvider.Get(EInventoryUseItemType.SilverOre), UpperCavesOfBanishment);
 			Add(new ItemKey(8, 3, 808, 144), "Caves of Banishment (Sirens): Siren room above water chest", ItemProvider.Get(EInventoryUseItemType.SilverOre), UpperCavesOfBanishment);
@@ -562,7 +562,7 @@ namespace TsRandomizer.Randomisation
 
 		public virtual bool IsBeatable()
 		{
-			if ((!SeedOptions.GassMaw && !IsGassMaskReachableWithTheMawRequirements())
+			if ((!SeedOptions.GasMaw && !IsGasMaskReachableWithTheMawRequirements())
 				|| ProgressiveItemsOfTheSameTypeAreInTheSameRoom())
 				return false;
 
@@ -594,12 +594,12 @@ namespace TsRandomizer.Randomisation
 						p => p.Key != progressiveItemLocation.Key && p.Key.ToRoomItemKey() == progressiveItemLocation.Key.ToRoomItemKey())));
 		}
 
-		bool IsGassMaskReachableWithTheMawRequirements()
+		bool IsGasMaskReachableWithTheMawRequirements()
 		{
-			//gassmask may never be placed in a gass effected place
-			//the very basics to reach maw should also allow you to get gassmask
+			//Gasmask may never be placed in a Gas effected place
+			//the very basics to reach maw should also allow you to get Gasmask
 			//unless we run inverted, then we can garantee the user has the pyramid keys before entering lake desolation
-			var gassmaskLocation = this.First(l => l.ItemInfo?.Identifier == new ItemIdentifier(EInventoryRelicType.AirMask));
+			var GasmaskLocation = this.First(l => l.ItemInfo?.Identifier == new ItemIdentifier(EInventoryRelicType.AirMask));
 
 			var levelIdsToAvoid = new List<int>(3) { 1 }; //lake desolation
 			var mawRequirements = R.None;
@@ -626,7 +626,7 @@ namespace TsRandomizer.Randomisation
 				mawRequirements |= UnlockingMap.PyramidKeysUnlock;
 			}
 
-			return !levelIdsToAvoid.Contains(gassmaskLocation.Key.LevelId) && gassmaskLocation.Gate.CanBeOpenedWith(mawRequirements);
+			return !levelIdsToAvoid.Contains(GasmaskLocation.Key.LevelId) && GasmaskLocation.Gate.CanBeOpenedWith(mawRequirements);
 		}
 
 		R GetObtainedRequirements(R obtainedRequirements)

--- a/TsRandomizer/Randomisation/ItemPlacers/FullRandomItemLocationRandomizer.cs
+++ b/TsRandomizer/Randomisation/ItemPlacers/FullRandomItemLocationRandomizer.cs
@@ -32,8 +32,8 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 		{
 			PlaceStarterProgressionItems(random, itemLocations);
 
-			if(!SeedOptions.GassMaw)
-				PlaceGassMaskInALegalSpot(random, itemLocations);
+			if(!SeedOptions.GasMaw)
+				PlaceGasMaskInALegalSpot(random, itemLocations);
 
 			var alreadyAssingedItems = itemLocations
 				.Where(l => l.IsUsed)

--- a/TsRandomizer/Randomisation/ItemPlacers/ItemLocationRandomizer.cs
+++ b/TsRandomizer/Randomisation/ItemPlacers/ItemLocationRandomizer.cs
@@ -155,7 +155,7 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 			PutItemAtLocation(ItemInfoProvider.Get(meleeOrbType, EOrbSlot.Melee), itemLocations[ItemKey.TutorialMeleeOrb]);
 		}
 
-		protected void PlaceGassMaskInALegalSpot(Random random, ItemLocationMap itemLocations)
+		protected void PlaceGasMaskInALegalSpot(Random random, ItemLocationMap itemLocations)
 		{
 			var levelIdsToAvoid = new List<int>(3) { 1 };
 			var minimalMawRequirements = R.None;
@@ -182,13 +182,13 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 				minimalMawRequirements |= UnlockingMap.PyramidKeysUnlock;
 			}
 
-			var gassMaskLocation = itemLocations
+			var GasMaskLocation = itemLocations
 				.Where(l => !l.IsUsed
 							&& !levelIdsToAvoid.Contains(l.Key.LevelId)
 							&& l.Gate.CanBeOpenedWith(minimalMawRequirements))
 				.SelectRandom(random);
 
-			PutItemAtLocation(ItemInfoProvider.Get(EInventoryRelicType.AirMask), gassMaskLocation);
+			PutItemAtLocation(ItemInfoProvider.Get(EInventoryRelicType.AirMask), GasMaskLocation);
 		}
 
 		protected void FillRemainingChests(Random random, ItemLocationMap itemLocations)

--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -70,7 +70,7 @@ namespace TsRandomizer.Randomisation
 				new UnlockingSpecification(new ItemIdentifier(EInventoryOrbType.Pink, EOrbSlot.Melee), R.PinkOrb),
 				new UnlockingSpecification(new ItemIdentifier(EInventoryOrbType.Pink, EOrbSlot.Spell), R.PinkOrb),
 				new UnlockingSpecification(new ItemIdentifier(EInventoryOrbType.Pink, EOrbSlot.Passive), R.PinkOrb),
-				new UnlockingSpecification(new ItemIdentifier(EInventoryRelicType.AirMask), R.GassMask),
+				new UnlockingSpecification(new ItemIdentifier(EInventoryRelicType.AirMask), R.GasMask),
 				new UnlockingSpecification(new ItemIdentifier(EInventoryRelicType.Tablet), R.Tablet),
 				new UnlockingSpecification(new ItemIdentifier(EInventoryOrbType.Eye, EOrbSlot.Passive), R.OculusRift),
 				new UnlockingSpecification(new ItemIdentifier(EInventoryFamiliarType.Kobo), R.Kobo),

--- a/TsRandomizer/Randomisation/Requirement.cs
+++ b/TsRandomizer/Randomisation/Requirement.cs
@@ -26,7 +26,7 @@ namespace TsRandomizer.Randomisation
 		public static readonly Requirement Swimming = 1UL << 11;
 		public static readonly Requirement UpwardDash = 1UL << 12;
 		public static readonly Requirement DoubleJump = 1UL << 13;
-		public static readonly Requirement GassMask = 1UL << 14;
+		public static readonly Requirement GasMask = 1UL << 14;
 		public static readonly Requirement Teleport = 1UL << 15;
 		public static readonly Requirement TimespinnerPiece1 = 1UL << 21;
 		public static readonly Requirement TimespinnerPiece2 = 1UL << 22;
@@ -147,7 +147,7 @@ namespace TsRandomizer.Randomisation
 				case "CardV": return "cV";
 				case "TimespinnerSpindle": return "Spindle";
 				case "Swimming": return "Sw";
-				case "GassMask": return "Gas";
+				case "GasMask": return "Gas";
 				case "Teleport": return "TP";
 				case "PinkOrb": return "PO";
 				default:

--- a/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
+++ b/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
@@ -14,7 +14,7 @@ namespace TsRandomizer.Screens.SeedSelection
 			{ 1 << 3, new SeedOptionInfo { Name = "Downloadable Items", Description = "With the tablet you will be able to download items from terminals." } },
 			{ 1 << 4, new SeedOptionInfo { Name = "Eye Spy", Description = "Requires Oculus Ring in inventory to be able to break hidden walls." } },
 			{ 1 << 5, new SeedOptionInfo { Name = "Start with Meyef", Description = "Start with Meyef, ideal for when you want to play multiplayer" } },
-			{ 1 << 6, new SeedOptionInfo { Name = "Quick seed", Description = "Start with Talaria Attachment, Nyoom!" } },
+			{ 1 << 6, new SeedOptionInfo { Name = "Quick Seed", Description = "Start with Talaria Attachment, Nyoom!" } },
 			{ 1 << 7, new SeedOptionInfo { Name = "Specific Keycards", Description = "Keycards can only open corresponding doors." } },
 			{ 1 << 8, new SeedOptionInfo { Name = "Inverted", Description = "Start in the past." } },
 			{ 1 << 9, new SeedOptionInfo { Name = "Stinky Maw", Description = "Require Gas Mask for Maw." } },

--- a/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
+++ b/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
@@ -8,17 +8,17 @@ namespace TsRandomizer.Screens.SeedSelection
 	{
 		static readonly Dictionary<int, SeedOptionInfo> Options = new Dictionary<int, SeedOptionInfo>
 		{
-			{ 1 << 0, new SeedOptionInfo { Name = "Start with Jewelry Box", Description = "Start with Jewelry Box unlocked" } },
-			{ 1 << 1, new SeedOptionInfo { Name = "Progressive vertical movement", Description = "Always find vertical movement in the following order Succubus Hairpin -> Light Wall -> Celestial Sash" } },
-			{ 1 << 2, new SeedOptionInfo { Name = "Progressive keycards", Description = "Always find Security Keycard's in the following order D -> C -> B -> A" } },
-			{ 1 << 3, new SeedOptionInfo { Name = "Downloadable items", Description = "With the tablet you will be able to download items at terminals" } },
-			{ 1 << 4, new SeedOptionInfo { Name = "Facebook mode", Description = "Requires Oculus Rift(ng) to spot the weakspots in walls and floors" } },
+			{ 1 << 0, new SeedOptionInfo { Name = "Start with Jewelry Box", Description = "Start with Jewelry Box unlocked." } },
+			{ 1 << 1, new SeedOptionInfo { Name = "Progressive Vertical Movement", Description = "Always find vertical movement in the following order: Succubus Hairpin -> Light Wall -> Celestial Sash." } },
+			{ 1 << 2, new SeedOptionInfo { Name = "Progressive Keycards", Description = "Always find Security Keycards in the following order D -> C -> B -> A." } },
+			{ 1 << 3, new SeedOptionInfo { Name = "Downloadable Items", Description = "With the tablet you will be able to download items from terminals." } },
+			{ 1 << 4, new SeedOptionInfo { Name = "Eye Spy", Description = "Requires Oculus Ring in inventory to be able to break hidden walls." } },
 			{ 1 << 5, new SeedOptionInfo { Name = "Start with Meyef", Description = "Start with Meyef, ideal for when you want to play multiplayer" } },
 			{ 1 << 6, new SeedOptionInfo { Name = "Quick seed", Description = "Start with Talaria Attachment, Nyoom!" } },
-			{ 1 << 7, new SeedOptionInfo { Name = "Specific Keycards", Description = "Keycards can only open corresponding doors" } },
-			{ 1 << 8, new SeedOptionInfo { Name = "Inverted", Description = "Start in the past" } },
-			{ 1 << 9, new SeedOptionInfo { Name = "Stinky Maw", Description = "Require gassmask for Maw" } },
-			{ 1 << 10, new SeedOptionInfo { Name = "Gyre Archives", Description = "Gyre locations are in logic. New warps are gated by Merchant Crow and Kobo." } },
+			{ 1 << 7, new SeedOptionInfo { Name = "Specific Keycards", Description = "Keycards can only open corresponding doors." } },
+			{ 1 << 8, new SeedOptionInfo { Name = "Inverted", Description = "Start in the past." } },
+			{ 1 << 9, new SeedOptionInfo { Name = "Stinky Maw", Description = "Require Gas Mask for Maw." } },
+			{ 1 << 10, new SeedOptionInfo { Name = "Gyre Archives", Description = "Temporal Gyre locations are in logic. New warps are gated by Merchant Crow and Kobo." } },
 			{ 1 << 11, new SeedOptionInfo { Name = "Cantoran", Description = "Cantoran's fight and check are available upon revisiting his room." } },
 			{ 1 << 12, new SeedOptionInfo { Name = "Lore Checks", Description = "Memories in the present and letters in the past contain items." } }
 		};

--- a/TsRandomizer/SeedOptions.cs
+++ b/TsRandomizer/SeedOptions.cs
@@ -16,12 +16,12 @@ namespace TsRandomizer
 		public bool ProgressiveVerticalMovement => (Flags & 1 << 1) > 0;
 		public bool ProgressiveKeycard => (Flags & 1 << 2) > 0;
 		public bool DownloadableItems => (Flags & 1 << 3) > 0;
-		public bool RequireEyeOrbRing => (Flags & 1 << 4) > 0;
+		public bool EyeSpy => (Flags & 1 << 4) > 0;
 		public bool StartWithMeyef => (Flags & 1 << 5) > 0;
 		public bool StartWithTalaria => (Flags & 1 << 6) > 0;
 		public bool SpecificKeys => (Flags & 1 << 7) > 0;
 		public bool Inverted => (Flags & 1 << 8) > 0;
-		public bool GassMaw => (Flags & 1 << 9) > 0;
+		public bool GasMaw => (Flags & 1 << 9) > 0;
 		public bool GyreArchives => (Flags & 1 << 10) > 0;
 		public bool Cantoran => (Flags & 1 << 11) > 0;
 		public bool LoreChecks => (Flags & 1 << 12) > 0;
@@ -44,7 +44,7 @@ namespace TsRandomizer
 				{"ProgressiveVerticalMovement", 1U << 1},
 				{"ProgressiveKeycards", 1U << 2},
 				{"DownloadableItems", 1U << 3},
-				{"FacebookMode", 1U << 4},
+				{"EyeSpy", 1U << 4},
 				{"StartWithMeyef", 1U << 5},
 				{"QuickSeed", 1U << 6},
 				{"SpecificKeycards", 1U << 7},


### PR DESCRIPTION
Per discussions in the Discord, the name Facebook Mode has lost its tenuous connection with the VR headset now known as the Meta Rift. Flag name has been renamed.

Minor text fixes to other flags and descriptions.