### PR TITLE
Remove Empty chests from filler pool

### DIFF
--- a/TsRandomizer/Randomisation/ItemPlacers/ItemLocationRandomizer.cs
+++ b/TsRandomizer/Randomisation/ItemPlacers/ItemLocationRandomizer.cs
@@ -74,8 +74,7 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 				ItemInfoProvider.Get(EInventoryUseItemType.ChaosHeal),
 				ItemInfoProvider.Get(EInventoryUseItemType.Antidote),
 				ItemInfoProvider.Get(EInventoryUseItemType.SandBottle),
-				ItemInfoProvider.Get(EInventoryUseItemType.HiSandBottle),
-				ItemInfoProvider.Get(EInventoryUseItemType.PlaceHolderItem1) // "Nothing"/empty chest
+				ItemInfoProvider.Get(EInventoryUseItemType.HiSandBottle)
 			};
 		}
 


### PR DESCRIPTION
There does not seem to be a high demand from the community for empty chests, removing it from the filler items pool

@JarnoWesthof 