### PR TITLE
Adjust Menus due to New Patch

### DIFF
--- a/TsRandomizer/Screens/GameplayScreen.cs
+++ b/TsRandomizer/Screens/GameplayScreen.cs
@@ -174,9 +174,6 @@ namespace TsRandomizer.Screens
 
 			deathLinkService?.Update(Level, ScreenManager);
 
-			if (Settings.MeleeAutofire.Value)
-				GamePadWrapper.GetProperty("IsMeleeDown").SetValue(Level.MainHero.AsDynamic()._gamePadWrapper, false, null);
-
 			if (Settings.ExtraEarringsXP.Value > 0)
 			{
 				OrbExperienceManager.UpdateHitRegistry(Level.MainHero);

--- a/TsRandomizer/Screens/OptionsMenuScreen.cs
+++ b/TsRandomizer/Screens/OptionsMenuScreen.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Timespinner.GameAbstractions;
 using Timespinner.GameStateManagement.ScreenManager;
@@ -31,6 +32,11 @@ namespace TsRandomizer.Screens
 			settingButton.DoesDrawLargeShadow = false;
 
 			var buttons = (IList)((object)Dynamic._primaryMenuCollection).AsDynamic()._entries;
+			// Delete Passwords Menu if present
+			if (buttons[buttons.Count - 1].AsDynamic().Text == "Passwords")
+			{
+				buttons.RemoveAt(buttons.Count - 1);
+			}
 			buttons.Add(settingButton.AsTimeSpinnerMenuEntry());
 
 			((object)Dynamic._primaryMenuCollection).AsDynamic()._entries = buttons.ToList(MainMenuEntryType);

--- a/TsRandomizer/Settings/GameSettingsLoader.cs
+++ b/TsRandomizer/Settings/GameSettingsLoader.cs
@@ -330,8 +330,6 @@ namespace TsRandomizer.Settings
 				SetNumberGameSetting(settings.LevelCap, levelCap);
 			if (slotData.TryGetValue("ExtraEarringsXP", out var extraEarringsXP))
 				SetNumberGameSetting(settings.ExtraEarringsXP, extraEarringsXP);
-			if (slotData.TryGetValue("MeleeAutofire", out var meleeAutofire))
-				settings.MeleeAutofire.Value = IsTrue(meleeAutofire);
 
 			if (slotData.TryGetValue("ShowDrops", out var showDrops))
 				settings.ShowDrops.Value = IsTrue(showDrops);

--- a/TsRandomizer/Settings/SettingCollection.cs
+++ b/TsRandomizer/Settings/SettingCollection.cs
@@ -45,7 +45,7 @@ namespace TsRandomizer.Settings
 				}},
 			new GameSettingCategoryInfo { Name = "Other", Description = "Miscellaneous settings",
 				SettingsPerCategory = new List<Func<SettingCollection, GameSetting>> {
-					s => s.ShowBestiary, s => s.ShowDrops, s => s.MeleeAutofire, s => s.NoSaveStatues, s => s.EnableMapFromStart
+					s => s.ShowBestiary, s => s.ShowDrops, s => s.NoSaveStatues, s => s.EnableMapFromStart
 				}}
 		};
 
@@ -258,10 +258,6 @@ namespace TsRandomizer.Settings
 
 		public NumberGameSetting ExtraEarringsXP = new NumberGameSetting("Extra Earrings XP",
 			"Adds additional XP granted by Galaxy Earrings", 0, 24, 1, 0, true);
-
-		[DoesNotAffectCompetitiveBalance]
-		public OnOffGameSetting MeleeAutofire = new OnOffGameSetting("Autofire (Melee)",
-			"Holding the melee attack button will attack repeatedly.", false, true);
 
 		public OnOffGameSetting NoSaveStatues = new OnOffGameSetting("No Save Statues",
 			"Breaks all the save statues", false, true);


### PR DESCRIPTION
Minor changes related to the new vanilla game patch.

Unused `Passwords` menu finally hidden, as with it still present the new `Player 2 Settings` pushes `Randomizer Settings` off the screen.

<img width="961" height="708" alt="image" src="https://github.com/user-attachments/assets/5f3ec028-4173-4681-a318-fdd66162180d" />


Removes autofire because the vanilla game added a cleaner version of it.
